### PR TITLE
fix(tmux): use server scope for extended-keys-format

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -105,4 +105,4 @@ set -g allow-passthrough on
 # Allow tmux to recognize extended key sequences (e.g. Shift+Enter)
 set -s extended-keys on
 set -as terminal-features 'xterm*:extkeys'
-set -g extended-keys-format csi-u
+set -s extended-keys-format csi-u


### PR DESCRIPTION
Changes `set -g` to `set -s` for the `extended-keys-format` option in .tmux.conf.

Since `extended-keys-format` is a tmux server option (just like `extended-keys`), it should be set using the `-s` (server) flag rather than the `-g` (global session/window) flag.

This correctly aligns the option's scope and ensures that CSI-u key formatting is properly applied at the server level, allowing tools like Pi to reliably receive modifier keys (e.g., Shift+Enter).