### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -5,7 +5,7 @@ alias :q="echo 'Nope. Not vim dummy.' && sleep 1 && exit"
 alias :e="echo 'Nope. Not vim dummy.' && sleep 1 && vim"
 
 # Common shorthands
-alias l="bat"  # Alias comes the fact that this used to be `less`
+alias l="bat"  # Alias comes from the fact that this used to be `less`
 alias cc="claude"
 alias g="git"
 alias t="tmux"

--- a/.bin/clip
+++ b/.bin/clip
@@ -1,5 +1,5 @@
 #!/bin/sh
-# copys the piped text to the clipboard
+# copies the piped text to the clipboard
 
 if [ "$(uname)" == "Darwin" ]; then
     cat "$@" | pbcopy

--- a/.gitconfig
+++ b/.gitconfig
@@ -12,7 +12,7 @@
 	defaultBranch = main
 
 [alias]
-# Ultility aliases. I am unlikely to call this myself, but other scripts use this.
+# Utility aliases. I am unlikely to call this myself, but other scripts use this.
 	default-branch = "!git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'"
 
 # Commit aliases
@@ -53,7 +53,7 @@
 	plu  = pull upstream
 	pof  = push origin --force-with-lease
 
-# Cloneing aliases
+# Cloning aliases
 	cl  = clone
 	clo = clone
 

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -18,7 +18,7 @@ set -sa terminal-overrides ",xterm-256color:Tc"
 
 set -g default-shell "/bin/zsh"
 
-# Shorted delay
+# Shorten delay
 set -s escape-time 1
 
 # Set window and pane numbering to be 1 indexed

--- a/.vim/ftdetect/typescript.vim
+++ b/.vim/ftdetect/typescript.vim
@@ -1,3 +1,3 @@
-" Created becase leafgarland/typescript-vim wasn't setting `tsx` correctly.
+" Created because leafgarland/typescript-vim wasn't setting `tsx` correctly.
 autocmd BufNewFile,BufRead *.ts  set filetype=typescript
 autocmd BufNewFile,BufRead *.tsx set filetype=typescript.tsx

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository is for managing my configuration files.
 
 ## Installation
 
-### 1.Clone this repo
+### 1. Clone this repo
 
-Clone the repo. I like to clone put it at `~/.dotfiles`
+Clone the repo. I like to put it at `~/.dotfiles`
 
     git clone git@github.com:hockeybuggy/dotfiles.git .dotfiles && cd .dotfiles
 


### PR DESCRIPTION
Several config comments and README lines had spelling and grammar mistakes (`Ultility`, `Cloneing`, `copys`, `becase`, `Shorted`) along with a couple of awkward phrasings in the `README` and `.aliases`.

Correct them all. These are comment and documentation changes only, with no behaviour changes.