### PR TITLE
Add cross-platform `setup` script and Docker test

### DIFF
--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -1,0 +1,14 @@
+name: Test setup
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test-setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install and verify tools in a clean Debian container
+        run: ./test/run.sh

--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -1,4 +1,4 @@
-name: Test setup
+name: Test setup.sh
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,30 @@ Clone the repo. I like to put it at `~/.dotfiles`
 
     git clone git@github.com:hockeybuggy/dotfiles.git .dotfiles && cd .dotfiles
 
-### 2. Automagically Link the files
+### 2. Install the tools
+
+`setup` installs the dependencies listed below. It works on macOS (via
+Homebrew) and Debian/Ubuntu (via apt plus a few official installers). It
+only installs tools -- it does not link any config.
+
+    ./setup
+
+### 3. Automagically Link the files
 
     ./bootstrap.sh
+
+## Testing `setup`
+
+You can exercise `setup` on a clean Debian container. This builds a minimal
+image, runs `setup` and `bootstrap.sh` inside it, then drives a tmux session
+to confirm each tool actually runs:
+
+    ./test/run.sh
+
+Pass `--interactive` to provision the container and drop into a shell so you
+can poke around in tmux yourself:
+
+    ./test/run.sh --interactive
 
 ## Dependencies
 
@@ -32,6 +53,7 @@ Clone the repo. I like to put it at `~/.dotfiles`
     1. [fzf](https://github.com/junegunn/fzf) -- Fuzzy finder
     1. [bat](https://github.com/sharkdp/bat) -- `cat` replacement
     1. [eza](https://eza.rocks/) -- `ls` replacement
+    1. [bottom](https://github.com/ClementTsang/bottom) -- `top` replacement (`btm`)
 1. Language things
     1. rustup, cargo, rustc
     1. python, black

--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@ Clone the repo. I like to put it at `~/.dotfiles`
 
 ### 2. Install the tools
 
-`setup` installs the dependencies listed below. It works on macOS (via
+`setup.sh` installs the dependencies listed below. It works on macOS (via
 Homebrew) and Debian/Ubuntu (via apt plus a few official installers). It
 only installs tools -- it does not link any config.
 
-    ./setup
+    ./setup.sh
 
 ### 3. Automagically Link the files
 
     ./bootstrap.sh
 
-## Testing `setup`
+## Testing `setup.sh`
 
-You can exercise `setup` on a clean Debian container. This builds a minimal
-image, runs `setup` and `bootstrap.sh` inside it, then drives a tmux session
+You can exercise `setup.sh` on a clean Debian container. This builds a minimal
+image, runs `setup.sh` and `bootstrap.sh` inside it, then drives a tmux session
 to confirm each tool actually runs:
 
     ./test/run.sh

--- a/setup
+++ b/setup
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+#
+# setup -- install the tools this dotfiles repo expects.
+#
+# Cross-platform: macOS (via Homebrew) and Debian/Ubuntu (via apt plus a few
+# official installers / prebuilt binaries). This script only *installs* tools;
+# run ./bootstrap.sh afterwards to symlink the config files into place.
+#
+# Idempotent: every install is guarded so re-running skips what's present.
+
+set -euo pipefail
+
+# Colours, matching bootstrap.sh's style.
+if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+    GREEN=$(tput setaf 2); YELLOW=$(tput setaf 3); RED=$(tput setaf 1); RESET=$(tput sgr0)
+else
+    GREEN=""; YELLOW=""; RED=""; RESET=""
+fi
+
+LOCAL_BIN="$HOME/.local/bin"
+
+info() { echo "${GREEN}==>${RESET} $*"; }
+skip() { echo "${YELLOW}--- skip:${RESET} $*"; }
+warn() { echo "${RED}!!! ${RESET}$*" >&2; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Download $1 to $2. Prefer curl, fall back to wget.
+download() {
+    if have curl; then
+        curl -fsSL "$1" -o "$2"
+    else
+        wget -qO "$2" "$1"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# macOS (Homebrew)
+# ---------------------------------------------------------------------------
+
+setup_macos() {
+    if ! have brew; then
+        info "Installing Homebrew"
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    else
+        skip "Homebrew already installed"
+    fi
+
+    info "Installing formulae with Homebrew"
+    brew install \
+        neovim tmux zsh git fzf ripgrep fd bat eza bottom starship zoxide \
+        uv fnm gnupg diff-so-fancy node markdownlint-cli \
+        reattach-to-user-namespace uutils-coreutils
+
+    info "Installing the Inconsolata Nerd Font"
+    brew install --cask font-inconsolata-nerd-font || warn "Font install failed (continuing)"
+
+    if ! have rustup && ! have cargo; then
+        info "Installing rustup"
+        brew install rustup
+        rustup default stable
+    else
+        skip "rustup/cargo already installed"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Debian / Ubuntu (apt + installers)
+# ---------------------------------------------------------------------------
+
+# Machine architecture normalised for release-asset URLs.
+arch_rust() {
+    case "$(uname -m)" in
+        x86_64|amd64) echo "x86_64" ;;
+        aarch64|arm64) echo "aarch64" ;;
+        *) warn "Unsupported architecture: $(uname -m)"; return 1 ;;
+    esac
+}
+
+arch_nvim() {
+    case "$(uname -m)" in
+        x86_64|amd64) echo "x86_64" ;;
+        aarch64|arm64) echo "arm64" ;;
+        *) warn "Unsupported architecture: $(uname -m)"; return 1 ;;
+    esac
+}
+
+# Install an eza/bottom-style GitHub release: a tarball whose sole payload is
+# the named binary. Args: <repo> <asset-url> <binary-name>
+install_release_binary() {
+    local name="$1" url="$2" bin="$3" tmp
+    if have "$bin"; then skip "$name already installed"; return; fi
+    info "Installing $name"
+    tmp=$(mktemp -d)
+    download "$url" "$tmp/dl.tar.gz"
+    tar -xzf "$tmp/dl.tar.gz" -C "$tmp"
+    # The binary may sit at the top level or one directory down.
+    local found
+    found=$(find "$tmp" -type f -name "$bin" | head -n 1)
+    if [ -z "$found" ]; then warn "Could not find $bin in $name release"; rm -rf "$tmp"; return 1; fi
+    install -m 0755 "$found" "$LOCAL_BIN/$bin"
+    rm -rf "$tmp"
+}
+
+apt_install() {
+    info "Updating apt and installing base packages"
+    sudo apt-get update -qq
+    sudo apt-get install -y --no-install-recommends \
+        zsh tmux git gnupg curl ca-certificates build-essential \
+        python3 python3-pip python3-venv ripgrep fd-find bat fzf unzip tar
+}
+
+# Debian ships fd as `fdfind` and bat as `batcat`; expose the usual names.
+link_debian_aliases() {
+    if have fdfind && ! have fd; then
+        info "Linking fdfind -> fd"
+        ln -sf "$(command -v fdfind)" "$LOCAL_BIN/fd"
+    fi
+    if have batcat && ! have bat; then
+        info "Linking batcat -> bat"
+        ln -sf "$(command -v batcat)" "$LOCAL_BIN/bat"
+    fi
+}
+
+setup_linux() {
+    if ! have apt-get; then
+        warn "This script only supports apt-based Linux (Debian/Ubuntu)."
+        exit 1
+    fi
+
+    mkdir -p "$LOCAL_BIN"
+    apt_install
+    link_debian_aliases
+
+    local ra na
+    ra=$(arch_rust)
+    na=$(arch_nvim)
+
+    # rustup / cargo
+    if ! have cargo && ! have rustup; then
+        info "Installing rustup"
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+    else
+        skip "rustup/cargo already installed"
+    fi
+
+    # starship
+    if ! have starship; then
+        info "Installing starship"
+        curl -sS https://starship.rs/install.sh | sh -s -- -y -b "$LOCAL_BIN"
+    else
+        skip "starship already installed"
+    fi
+
+    # zoxide
+    if ! have zoxide; then
+        info "Installing zoxide"
+        curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
+    else
+        skip "zoxide already installed"
+    fi
+
+    # uv
+    if ! have uv; then
+        info "Installing uv"
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    else
+        skip "uv already installed"
+    fi
+
+    # eza and bottom (prebuilt release binaries)
+    install_release_binary "eza" \
+        "https://github.com/eza-community/eza/releases/latest/download/eza_${ra}-unknown-linux-gnu.tar.gz" \
+        "eza"
+    install_release_binary "bottom" \
+        "https://github.com/ClementTsang/bottom/releases/latest/download/bottom_${ra}-unknown-linux-gnu.tar.gz" \
+        "btm"
+
+    # neovim (official tarball; apt's is far older than the README's 11.0)
+    if ! have nvim; then
+        info "Installing neovim"
+        local tmp
+        tmp=$(mktemp -d)
+        download "https://github.com/neovim/neovim/releases/latest/download/nvim-linux-${na}.tar.gz" "$tmp/nvim.tar.gz"
+        tar -xzf "$tmp/nvim.tar.gz" -C "$HOME/.local" --strip-components=1
+        rm -rf "$tmp"
+    else
+        skip "neovim already installed"
+    fi
+
+    # fnm + node + npm-distributed tools (markdownlint-cli, diff-so-fancy)
+    if ! have fnm; then
+        info "Installing fnm"
+        curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "$HOME/.local/share/fnm" --skip-shell
+    else
+        skip "fnm already installed"
+    fi
+    export PATH="$HOME/.local/share/fnm:$LOCAL_BIN:$PATH"
+    if have fnm; then
+        # --shell bash: fnm can't infer the shell from a non-interactive script.
+        eval "$(fnm env --shell bash)"
+        if ! fnm ls 2>/dev/null | grep -q 'v[0-9]'; then
+            info "Installing the LTS Node via fnm"
+            fnm install --lts
+        fi
+        fnm use lts-latest >/dev/null 2>&1 || true
+        fnm default lts-latest >/dev/null 2>&1 || true
+        if have npm; then
+            have markdownlint || { info "Installing markdownlint-cli"; npm install -g markdownlint-cli; }
+            have diff-so-fancy || { info "Installing diff-so-fancy"; npm install -g diff-so-fancy; }
+        fi
+    fi
+
+    skip "reattach-to-user-namespace, uutils-coreutils and Nerd Font are macOS-only"
+}
+
+# ---------------------------------------------------------------------------
+
+main() {
+    case "$(uname -s)" in
+        Darwin) info "Detected macOS"; setup_macos ;;
+        Linux)  info "Detected Linux";  setup_linux ;;
+        *) warn "Unsupported OS: $(uname -s)"; exit 1 ;;
+    esac
+
+    echo
+    info "Done. Tools installed."
+    echo "${YELLOW}Note:${RESET} some tools install into ~/.local/bin, ~/.cargo/bin and"
+    echo "      ~/.local/share/fnm -- the dotfiles' .zshrc adds these to PATH."
+    echo "      Run ${GREEN}./bootstrap.sh${RESET} next to symlink the config files."
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# setup -- install the tools this dotfiles repo expects.
+# setup.sh -- install the tools this dotfiles repo expects.
 #
 # Cross-platform: macOS (via Homebrew) and Debian/Ubuntu (via apt plus a few
 # official installers / prebuilt binaries). This script only *installs* tools;

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,19 @@
+# Minimal Debian image for testing ./setup from a near-bare system.
+#
+# We install only what's needed to *bootstrap* the setup script (curl, git,
+# sudo, locales); everything else is left for ./setup to install, so the test
+# exercises the real install path.
+FROM debian:stable-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        sudo curl ca-certificates git locales ncurses-base ncurses-term && \
+    sed -i 's/# en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen && locale-gen && \
+    useradd -m -s /bin/bash tester && \
+    echo 'tester ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tester && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+USER tester
+WORKDIR /home/tester

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,7 @@
-# Minimal Debian image for testing ./setup from a near-bare system.
+# Minimal Debian image for testing ./setup.sh from a near-bare system.
 #
 # We install only what's needed to *bootstrap* the setup script (curl, git,
-# sudo, locales); everything else is left for ./setup to install, so the test
+# sudo, locales); everything else is left for ./setup.sh to install, so the test
 # exercises the real install path.
 FROM debian:stable-slim
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# run.sh -- test ./setup on a clean Debian container.
+#
+# Builds a minimal Debian image, runs ./setup and ./bootstrap.sh inside a fresh
+# container, then drives a tmux session (via verify.sh) to prove each installed
+# tool actually runs.
+#
+# Usage:
+#   ./test/run.sh                 # provision + automated tmux verification
+#   ./test/run.sh --interactive   # provision, then drop into a zsh shell to poke
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+IMAGE=dotfiles-test
+INTERACTIVE=0
+
+case "${1:-}" in
+    "") ;;
+    -i|--interactive|--shell) INTERACTIVE=1 ;;
+    -h|--help) echo "Usage: $0 [--interactive]"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; echo "Usage: $0 [--interactive]" >&2; exit 1 ;;
+esac
+
+echo "==> Building $IMAGE image"
+docker build -t "$IMAGE" "$REPO_ROOT/test"
+
+# Copy the read-only mount into a writable home, put the freshly installed
+# binaries on PATH, then install + symlink. Single-quoted on purpose: these
+# variables must expand inside the container, not on the host.
+# shellcheck disable=SC2016
+PROVISION='set -e
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+case "${TERM:-}" in ""|dumb) export TERM=xterm ;; esac   # bootstrap.sh/verify.sh call tput; a non-tty run gives TERM=dumb, which has no colour caps
+cp -r /dotfiles "$HOME/.dotfiles"
+cd "$HOME/.dotfiles"
+./setup
+./bootstrap.sh'
+
+if [ "$INTERACTIVE" -eq 1 ]; then
+    echo "==> Provisioning, then dropping into an interactive shell"
+    docker run --rm -it -v "$REPO_ROOT:/dotfiles:ro" "$IMAGE" bash -lc "
+$PROVISION
+echo
+echo 'Provisioned. Try: tmux, then eza --long / btm / rg / fzf / starship'
+exec zsh -l"
+else
+    echo "==> Provisioning and verifying"
+    docker run --rm -v "$REPO_ROOT:/dotfiles:ro" "$IMAGE" bash -lc "
+$PROVISION
+exec ./test/verify.sh"
+fi

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# run.sh -- test ./setup on a clean Debian container.
+# run.sh -- test ./setup.sh on a clean Debian container.
 #
-# Builds a minimal Debian image, runs ./setup and ./bootstrap.sh inside a fresh
+# Builds a minimal Debian image, runs ./setup.sh and ./bootstrap.sh inside a fresh
 # container, then drives a tmux session (via verify.sh) to prove each installed
 # tool actually runs.
 #
@@ -13,6 +13,8 @@
 set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+"$REPO_ROOT/test/setup-script-name.sh"
+
 IMAGE=dotfiles-test
 INTERACTIVE=0
 
@@ -35,7 +37,7 @@ export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 case "${TERM:-}" in ""|dumb) export TERM=xterm ;; esac   # bootstrap.sh/verify.sh call tput; a non-tty run gives TERM=dumb, which has no colour caps
 cp -r /dotfiles "$HOME/.dotfiles"
 cd "$HOME/.dotfiles"
-./setup
+./setup.sh
 ./bootstrap.sh'
 
 if [ "$INTERACTIVE" -eq 1 ]; then

--- a/test/setup-script-name.sh
+++ b/test/setup-script-name.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Verify that the installer uses the same explicit shell-script suffix as
+# bootstrap.sh.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+
+test -x "$repo_root/setup.sh"
+test ! -e "$repo_root/setup"

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# verify.sh -- run inside the test container after ./setup and ./bootstrap.sh.
+# verify.sh -- run inside the test container after ./setup.sh and ./bootstrap.sh.
 #
 # Drives a tmux session running a login zsh and exercises each installed tool,
 # capturing its output to prove it actually runs. Prints a pass/fail summary

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# verify.sh -- run inside the test container after ./setup and ./bootstrap.sh.
+#
+# Drives a tmux session running a login zsh and exercises each installed tool,
+# capturing its output to prove it actually runs. Prints a pass/fail summary
+# and exits non-zero if anything is missing.
+
+set -uo pipefail
+
+if command -v tput >/dev/null 2>&1 && [ -n "${TERM:-}" ]; then
+    GREEN=$(tput setaf 2 2>/dev/null || echo); RED=$(tput setaf 1 2>/dev/null || echo)
+    BOLD=$(tput bold 2>/dev/null || echo); RESET=$(tput sgr0 2>/dev/null || echo)
+else
+    GREEN=""; RED=""; BOLD=""; RESET=""
+fi
+
+# Make every installed tool resolvable regardless of the .zshrc fnm path quirk.
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.local/share/fnm:$PATH"
+# shellcheck source=/dev/null
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+if command -v fnm >/dev/null 2>&1; then
+    eval "$(fnm env --shell bash)" 2>/dev/null || true
+    fnm use lts-latest >/dev/null 2>&1 || true
+fi
+
+# "label|command" -- the command must exit 0. Most print a version; diff-so-fancy
+# is a stdin filter with no version flag (it would block on the pane's tty), so we
+# just confirm it resolves on PATH.
+checks=(
+    "eza|eza --version"
+    "bat|bat --version"
+    "ripgrep (rg)|rg --version"
+    "fd|fd --version"
+    "fzf|fzf --version"
+    "bottom (btm)|btm --version"
+    "starship|starship --version"
+    "zoxide|zoxide --version"
+    "neovim|nvim --version"
+    "tmux|tmux -V"
+    "zsh|zsh --version"
+    "git|git --version"
+    "cargo|cargo --version"
+    "rustc|rustc --version"
+    "uv|uv --version"
+    "python3|python3 --version"
+    "pip|pip3 --version"
+    "node|node --version"
+    "npm|npm --version"
+    "diff-so-fancy|command -v diff-so-fancy"
+    "markdownlint|markdownlint --version"
+)
+
+SOCK="verify"
+tmux -L "$SOCK" kill-server 2>/dev/null || true
+# A login zsh so the demo runs through the real .zshrc (aliases, starship, ...).
+tmux -L "$SOCK" new-session -d -s v -x 220 -y 60 zsh
+# Give the shell a moment to source .zshrc before we start driving it.
+sleep 2
+
+results=()   # "label|status|detail"
+failures=0
+
+echo "${BOLD}Exercising tools in tmux...${RESET}"
+for i in "${!checks[@]}"; do
+    label="${checks[$i]%%|*}"
+    cmd="${checks[$i]#*|}"
+
+    # Fresh screen per check keeps capture-pane unambiguous. The DONE marker is
+    # built with a %d format so the *typed* command line (which shows the literal
+    # "%d") never matches the resolved "DONE_i_RCn" we poll for.
+    tmux -L "$SOCK" send-keys -t v \
+        "clear; printf '### %s ###\\n' \"$label\"; $cmd; printf 'DONE_${i}_RC%d\\n' \"\$?\"" Enter
+
+    out=""
+    for _ in $(seq 1 60); do
+        out=$(tmux -L "$SOCK" capture-pane -p -t v 2>/dev/null || echo)
+        if printf '%s\n' "$out" | grep -Eq "DONE_${i}_RC[0-9]"; then
+            break
+        fi
+        sleep 0.25
+    done
+
+    rc=$(printf '%s\n' "$out" | sed -n "s/.*DONE_${i}_RC\([0-9][0-9]*\).*/\1/p" | tail -1)
+    # First line of the command's own output, for the summary.
+    detail=$(printf '%s\n' "$out" | awk '/^### /{f=1;next} /DONE_'"$i"'_RC/{f=0} f && NF {print; exit}')
+
+    if [ "${rc:-1}" = "0" ]; then
+        results+=("$label|ok|$detail")
+        printf '  %s✓%s %-16s %s\n' "$GREEN" "$RESET" "$label" "$detail"
+    else
+        results+=("$label|FAIL|not found / non-zero exit")
+        failures=$((failures + 1))
+        printf '  %s✗%s %-16s %s\n' "$RED" "$RESET" "$label" "not found / non-zero exit"
+    fi
+done
+
+tmux -L "$SOCK" kill-server 2>/dev/null || true
+
+echo
+echo "${BOLD}Summary${RESET}"
+printf '%s\n' "-------------------------------------------------------------"
+for r in "${results[@]}"; do
+    label="${r%%|*}"; rest="${r#*|}"; status="${rest%%|*}"; detail="${rest#*|}"
+    if [ "$status" = "ok" ]; then
+        printf '  %s%-6s%s %-16s %s\n' "$GREEN" "PASS" "$RESET" "$label" "$detail"
+    else
+        printf '  %s%-6s%s %-16s %s\n' "$RED" "FAIL" "$RESET" "$label" "$detail"
+    fi
+done
+printf '%s\n' "-------------------------------------------------------------"
+
+total=${#checks[@]}
+passed=$((total - failures))
+if [ "$failures" -eq 0 ]; then
+    echo "${GREEN}${BOLD}All $total tools verified.${RESET}"
+    exit 0
+else
+    echo "${RED}${BOLD}$passed/$total passed, $failures failed.${RESET}"
+    exit 1
+fi


### PR DESCRIPTION
`bootstrap.sh` only symlinks config files into `$HOME`; it assumes every tool in the README's dependency list is already installed. Provisioning a fresh machine was therefore a manual chore, and nothing verified that the expected tools were actually present.

Add a `setup` script that installs those dependencies on both macOS (via Homebrew) and Debian/Ubuntu (via apt plus a few official installers and prebuilt binaries). It is install-only and idempotent, leaving symlinking to `bootstrap.sh`.

Add a Docker-based test under `test/` that runs `setup` on a clean Debian image, symlinks with `bootstrap.sh`, then drives a tmux session to confirm each installed tool actually runs. `./test/run.sh` builds and verifies; `--interactive` drops into the provisioned container. Document both scripts in the README and add `bottom` to the dependency list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
