### PR TITLE
Add deep merge for Claude settings

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,9 +93,20 @@ function doIt() {
     if [ -f ".claude/settings.local.json" ]; then
         python3 -c "
 import json, sys
+
+def deep_merge(base, local):
+    # Recursively merge so nested dicts (e.g. permissions.ask and
+    # permissions.allow) are combined rather than wholesale replaced.
+    for key, value in local.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
 base = json.load(open('.claude/settings.json'))
 local = json.load(open('.claude/settings.local.json'))
-base.update(local)
+deep_merge(base, local)
 json.dump(base, open(sys.argv[1], 'w'), indent=2)
 print('Merged .claude/settings.json + settings.local.json -> ' + sys.argv[1])
 " "$HOME/.claude/settings.json"


### PR DESCRIPTION
Local permission allowances replaced the entire `permissions` object, discarding the tracked rules that require confirmation for sensitive GitHub comment and review actions.

Recursively merge nested settings objects so local additions preserve the shared configuration. Lists and scalar values still use the local value.