### PR TITLE
Name tmux windows by Claude Code session state

### DIFF
--- a/.claude/hooks/tmux-title.sh
+++ b/.claude/hooks/tmux-title.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Rename the current tmux window to reflect Claude Code's state.
+#
+# tmux's automatic-rename names each window after the pane's running process,
+# but Claude Code sets its process title to its version string (e.g. 2.1.206),
+# so the window ends up labelled with a version number instead of anything
+# useful. These hooks override that with a status emoji plus the project name,
+# and restore automatic-rename when the session ends.
+#
+# Usage: tmux-title.sh <emoji>   # rename window to "<emoji> <project>"
+#        tmux-title.sh --reset   # re-enable tmux automatic-rename
+
+# Nothing to do outside tmux.
+[ -z "${TMUX:-}" ] && exit 0
+
+# Resolve the window index from the active pane.
+if [ -n "${TMUX_PANE:-}" ]; then
+    window=$(tmux display-message -t "$TMUX_PANE" -p '#I' 2>/dev/null)
+else
+    window=$(tmux display-message -p '#I' 2>/dev/null)
+fi
+[ -z "$window" ] && exit 0
+
+if [ "$1" = "--reset" ]; then
+    tmux set-window-option -t "$window" automatic-rename on
+    exit 0
+fi
+
+emoji="${1:-🤖}"
+project=$(basename "${CLAUDE_PROJECT_DIR:-$PWD}")
+
+# Pin the name so automatic-rename can't clobber it with the version string.
+tmux set-window-option -t "$window" automatic-rename off
+tmux rename-window -t "$window" "$emoji $project"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,26 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/tmux-title.sh 🤖"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/tmux-title.sh ⚡"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "AskUserQuestion",
@@ -41,6 +61,14 @@
             "command": "bash ~/.claude/hooks/notify.sh"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/tmux-title.sh 💬"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -49,6 +77,24 @@
           {
             "type": "command",
             "command": "bash ~/.claude/hooks/done.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/tmux-title.sh 🤖"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/tmux-title.sh --reset"
           }
         ]
       }


### PR DESCRIPTION
tmux's automatic-rename names each window after the running process in its active pane. Claude Code sets its process title to its version string, which Node propagates to the OS process name, so windows show a bare version number (e.g. 2.1.206) instead of anything that says which project or what the session is doing. This is a known upstream bug that was closed as not planned, so it has to be worked around locally.

Add a `tmux-title.sh` hook script and wire it into the Claude Code hook events in `settings.json`. On each relevant event it renames the current window to a status emoji plus the project name — idle on `SessionStart`/`Stop`, working on `UserPromptSubmit`, needs-attention on `Notification` — and pins `automatic-rename` off so the version string can't clobber it. `SessionEnd` restores `automatic-rename` so the window behaves normally once Claude exits.

The script follows the existing `notify.sh`/`done.sh` pattern and is guarded to no-op outside tmux; `bootstrap.sh` already symlinks it via its `hooks/*.sh` loop, so no bootstrap change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
