### PR TITLE
Bring agent-stuff skills into the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.pyc
 *.pyo
 
+node_modules/
+
 *.o
 *.so
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,11 @@ The `.claude/` directory contains global Claude Code config. The
 bootstrap script handles it specially — it symlinks `CLAUDE.md` and
 merges `settings.json` with `settings.local.json` (if present).
 
+The `agents/skills/` directory holds Agent Skills (one `SKILL.md` per
+subdirectory) shared by Claude Code and the Pi coding agent. Bootstrap
+links each into `~/.claude/skills/` for Claude and points
+`~/.pi/agent/skills` at the directory for Pi.
+
 Keep changes focused. Don't over-engineer things.
 
 Please use Canadian spelling (e.g., colour, centre, travelling, defence) in your responses and when writing code/documentation.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ can poke around in tmux yourself:
     1. node, fnm, prettier
     1. luarocks, stylua
     1. rbenv, rubocop, solargraph
+1. Coding agents
+    1. [Claude Code](https://claude.com/claude-code)
+    1. [Pi](https://pi.dev)
 1. [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli)
 1. Git related
     1. gnupg

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ only installs tools -- it does not link any config.
 
     ./bootstrap.sh
 
+## Agent skills
+
+The `agents/skills/` directory holds [Agent Skills](https://agentskills.io)
+(one `SKILL.md` per subdirectory) shared by
+[Claude Code](https://claude.ai/code) and the
+[Pi coding agent](https://shittycodingagent.ai). `bootstrap.sh` links each into
+`~/.claude/skills/` for Claude and points `~/.pi/agent/skills` at the directory
+for Pi.
+
 ## Checking a machine with `doctor.sh`
 
 Run the doctor after installation to check required tools, linked config,
@@ -72,8 +81,6 @@ can poke around in tmux yourself:
     1. node, fnm, prettier
     1. luarocks, stylua
     1. rbenv, rubocop, solargraph
-1. Coding Agents
-    1. [agent-stuff](https://github.com/hockeybuggy/agent-stuff)
 1. [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli)
 1. Git related
     1. gnupg

--- a/agents/skills/commit/SKILL.md
+++ b/agents/skills/commit/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: commit
+description: "Read this skill before making git commits"
+---
+
+Create a git commit for the current changes. Match the repo's existing
+commit style — don't impose a format the repo doesn't already use.
+
+## Determining the format
+
+Run `git log -n 30 --pretty=format:%s` and look at recent subjects:
+
+- If most subjects use Conventional Commits (`feat:`, `fix(scope):`,
+  etc.), follow that convention.
+- Otherwise, write a plain imperative subject (e.g., `Fix the quoting
+  of the clip command`). Capitalize the first word, no trailing period.
+
+Project `CLAUDE.md` or user instructions take precedence over what you
+infer from history. If they specify a style, follow it.
+
+## Subject
+
+- Imperative mood, no trailing period.
+- Keep it short. Match the repo's typical length; if unclear, aim for
+  ~50 characters and stop at 72.
+- Wrap file names, variables, commands, and code references in
+  backticks.
+
+## Body
+
+Include a body when the subject doesn't say it all — typically for
+non-trivial changes. The body should answer: what was the state
+before, how does this change address it, and are there side effects.
+
+Skip the body for trivial changes where the subject is self-explanatory
+(typo fixes, renames, simple config tweaks).
+
+When you do write a body:
+
+- Wrap lines at ~72 characters.
+- Separate paragraphs with a blank line.
+- Use backticks around file names, variables, and code references.
+- Optionally add a final paragraph on alternatives considered, when
+  the chosen approach isn't obvious.
+
+## Other notes
+
+- Do NOT include breaking-change markers or footers.
+- Do NOT add sign-offs (no `Signed-off-by`).
+- Only commit; do NOT push.
+- If it is unclear whether a file should be included, ask the user
+  which files to commit.
+- Treat any caller-provided arguments as additional commit guidance:
+  - Freeform instructions should influence scope, summary, and body.
+  - File paths or globs should limit which files to commit. If files
+    are specified, only stage/commit those unless the user explicitly
+    asks otherwise.
+  - If arguments combine files and instructions, honor both.
+
+## Steps
+
+1. Infer from the prompt if the user provided specific file paths/globs
+   and/or additional instructions.
+2. Check the current branch. If on `main` or `master`, ask the user to
+   confirm they really want to commit there. If they don't, ask for the
+   branch name they'd like to use and switch (or create) that branch
+   before continuing.
+3. Review `git status` and `git diff` to understand the current changes
+   (limit to argument-specified files if provided).
+4. Run `git log -n 30 --pretty=format:%s` to determine the repo's
+   commit style and commonly used scopes.
+5. If there are ambiguous extra files, ask the user for clarification
+   before committing.
+6. Stage only the intended files (all changes if no files specified).
+7. Show the user the proposed commit message (subject and body) and
+   wait for approval before creating the commit. Apply any requested
+   edits and re-confirm. Use `AskUserQuestion` for a structured
+   approve/edit prompt when available, otherwise plain text. If the
+   user explicitly opts out of review for the current task (e.g.
+   "just commit", "no need to review"), skip the prompt.
+8. Run `git commit -m "<subject>"` (and `-m "<body>"` if needed).

--- a/agents/skills/create-linear-issue/SKILL.md
+++ b/agents/skills/create-linear-issue/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: create-linear-issue
+description: "Create a Linear issue with consistent structure, inheriting context from related issues when possible"
+---
+
+Create a Linear issue from the current conversation. Triggers on
+"create a Linear issue", "file a ticket", "open a Linear issue",
+"make a Linear issue for X".
+
+## Load the tools first
+
+The Linear MCP tools are deferred and must be loaded before they can
+be called. Run:
+
+```
+ToolSearch query="select:mcp__claude_ai_Linear__save_issue,mcp__claude_ai_Linear__get_issue"
+```
+
+Calling either tool without loading its schema first will fail with
+`InputValidationError`.
+
+## String values
+
+The Linear MCP server requires real newlines in markdown content, not
+literal `\n` escape sequences. Pass description strings with actual
+line breaks.
+
+## Inherit context from a related issue
+
+If the new issue is a follow-up, cleanup, child, or otherwise tied to
+an existing issue, call `mcp__claude_ai_Linear__get_issue` on that
+issue first and reuse:
+
+- `team` ID
+- `project` ID
+- `projectMilestone` ID (if set)
+- Labels, if they obviously apply
+
+Don't ask the user for fields you can pull from the related issue.
+
+When the user references issues for `parent`, `blocks`, or `related`,
+use the Linear identifier format (e.g. `DRWFA-1234`), not the internal
+UUID.
+
+## Required fields
+
+- `title`
+- `team` (UUID)
+
+Everything else is optional. Set what you can infer; ask about the
+rest only when it matters.
+
+## Clarifying questions
+
+Use `AskUserQuestion` for fields that can't be inferred and are likely
+to matter. Typical asks:
+
+- Assignee: me (Douglas) / unassigned / someone else
+- Priority: Urgent / High / Medium / Low / none
+- Due date
+- Labels
+
+Skip the question when context makes the answer obvious. Don't ask
+about the team or project if you inherited them.
+
+## Description style
+
+- Concrete file paths, function names, PR numbers, and issue IDs.
+- Structured sections with `##` headings (e.g. `## What to remove`,
+  `## What to keep`, `## When`, `## Context`).
+- Reference the originating PR or conversation under a `## Context`
+  section so the reader can find the source of truth.
+- No generic boilerplate, no marketing language, no emojis.
+- Use `@displayName` to mention people.
+
+## Steps
+
+1. Identify whether the issue relates to an existing one. If so,
+   `get_issue` on the related issue and capture team / project /
+   milestone IDs.
+2. Draft a title (short, imperative, specific) and a structured
+   description with concrete identifiers.
+3. Ask only the clarifying questions you actually need
+   (assignee, priority, due date, labels).
+4. Show the user the proposed title, description, and metadata, and
+   wait for approval before creating. If the user explicitly opts out
+   ("just create it"), skip the prompt.
+5. Call `mcp__claude_ai_Linear__save_issue` with the collected fields.
+6. Return the issue URL and a one-line summary:
+   `DRWFA-1234 — <title> (assignee: X, priority: Y, due: Z)`.

--- a/agents/skills/dispatching-parallel-agents/SKILL.md
+++ b/agents/skills/dispatching-parallel-agents/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dispatching-parallel-agents
+description: Structures and dispatches independent tasks for parallel execution across multiple Claude sessions or subagents. Use when a plan contains tasks that don't depend on each other and could be worked on simultaneously. Triggers on "do these in parallel", "work on multiple tasks at once", "split the work", or when an implementation plan has clearly independent components. Identify parallelizable work and provide ready-to-paste prompts for each parallel workstream.
+---
+
+# Dispatching Parallel Agents
+
+**Announce:** "I'm using the dispatching-parallel-agents skill to identify parallel workstreams."
+
+## When to Parallelize
+
+Tasks are parallelizable when they:
+- Touch different files/modules
+- Don't depend on each other's output
+- Could be code-reviewed independently
+- Have clearly defined interfaces between them
+
+**Do NOT parallelize** tasks that share state, modify the same files, or where Task B requires Task A's output.
+
+## Process
+
+### 1. Identify Independent Groups
+
+Review the plan and group tasks by independence:
+
+```
+Group A (can run in parallel with B):
+  - Task 2: Add User model
+  - Task 3: Add auth middleware
+
+Group B (can run in parallel with A):
+  - Task 4: Add API client wrapper
+  - Task 5: Write API integration tests
+
+Sequential (must run after A and B):
+  - Task 6: Wire auth to API client
+```
+
+### 2. Write a Dispatch Prompt for Each Agent
+
+For each parallel workstream, write a self-contained prompt that includes:
+- The full context the agent needs (don't assume it has project knowledge)
+- The specific tasks to complete
+- How to verify success (test commands)
+- What to commit when done
+
+**Template:**
+```
+You are working in a git worktree for feature/[name].
+The codebase is a [brief description].
+
+Your task: [specific tasks]
+
+Files to modify:
+- [exact file paths]
+
+How to verify your work:
+- Run: [test command]
+- Expected: [expected output]
+
+When done, commit with message: "[prefix]: [description]"
+```
+
+### 3. Launch and Monitor
+
+Open one Claude session per workstream. Paste the dispatch prompt. Let them run independently. Collect and review their outputs before merging.
+
+## Merging Results
+
+After all agents complete:
+1. Review each branch's diff before merging
+2. Look for conflicts in shared files
+3. Run the full test suite after merging all branches
+4. Resolve any integration issues before declaring done

--- a/agents/skills/edit-commit-message/SKILL.md
+++ b/agents/skills/edit-commit-message/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: edit-commit-message
+description: "Run `git commit` (or `--amend`) with the message editor opened in a new tmux pane so the user can hand-edit interactively. Uses git's own editor flow, so `commit.verbose=true` shows the diff as usual. Waits for the editor to close, then continues. Use when the user wants to write or tweak a commit message in vim/nvim. Requires the agent to be running inside a tmux session."
+---
+
+# Edit Commit Message Skill
+
+Hand commit-message editing off to nvim in a new tmux pane, then
+resume once the user saves and quits.
+
+The key idea: don't reinvent git's editor flow. Just point `GIT_EDITOR`
+at a tiny wrapper script (shipped alongside this skill) that opens its
+file argument in a tmux pane and blocks until the pane closes. Git
+takes care of including the diff, stripping comments, and aborting on
+empty messages.
+
+## When to use
+
+- User asks to edit a proposed commit message themselves.
+- User wants to see the diff in the editor (their `commit.verbose=true`
+  setting just works through this skill).
+- Reword / amend flows: `git commit --amend`, fixing the last message.
+
+For trivial subjects ("typo: fix x") just commit directly via the
+`commit` skill — don't bother with this.
+
+## Prerequisites
+
+- The agent must inherit `$TMUX` from the user's session. Without it,
+  the wrapper script bails with a clear error. If `$TMUX` is empty,
+  ask the user to either run the agent from inside tmux or approve
+  the message in chat.
+- The wrapper uses the **user's default tmux server** (no `-L agent`)
+  — the pane has to be visible to the user.
+
+## How to invoke
+
+```bash
+GIT_EDITOR="$AGENT_STUFF/skills/edit-commit-message/git-editor.sh" \
+  git commit
+```
+
+For amend:
+
+```bash
+GIT_EDITOR="$AGENT_STUFF/skills/edit-commit-message/git-editor.sh" \
+  git commit --amend
+```
+
+Resolve the absolute path to `git-editor.sh` from this skill's
+directory — don't hardcode `~/.agent-stuff/...` paths into the
+command, derive them from where `SKILL.md` lives.
+
+If the user does *not* have `commit.verbose=true` in their gitconfig
+and wants the diff this one time, add `-v`:
+
+```bash
+GIT_EDITOR=".../git-editor.sh" git commit -v
+```
+
+## What the wrapper does
+
+`git-editor.sh` is what git invokes in place of vim. It:
+
+1. Refuses to run if `$TMUX` is unset.
+2. Resolves an editor: `nvim` if available, else `vim`. (Shell aliases
+   don't apply because tmux runs commands via `/bin/sh -c`.)
+3. `tmux split-window` runs the editor on the file git passed in,
+   with `; touch <sentinel>; tmux kill-pane` appended so the pane
+   closes even when the user has `remain-on-exit on`.
+4. Polls for the sentinel file (normal exit) or pane disappearance
+   (external kill).
+5. Returns to git, which then commits / aborts as usual.
+
+Read the script if you need to tweak the split direction or polling:
+`skills/edit-commit-message/git-editor.sh`.
+
+## Variations
+
+### Use a horizontal split or a new window
+
+Edit `git-editor.sh` and change `split-window -v` to `split-window -h`
+or `new-window`. The capture / poll logic is the same regardless.
+
+### Use with interactive rebase
+
+`GIT_EDITOR` is also what git uses for the rebase todo list and for
+reword stops, so this works transparently:
+
+```bash
+GIT_EDITOR=".../git-editor.sh" git rebase -i HEAD~3
+```
+
+Each editor invocation opens its own pane in turn.
+
+### Use as the default editor everywhere
+
+If the user wants this behavior outside the agent too, they can put
+the script on their `GIT_EDITOR` permanently in their shell profile.
+That's their call, not the agent's.
+
+## Pitfalls
+
+- **No `$TMUX`.** The wrapper exits 1 with a clear message. Don't
+  swallow that — surface it to the user and fall back to approving
+  the message in chat.
+- **Don't write the message and pass `-F -`.** That was the previous
+  version of this skill, and it bypasses `commit.verbose`, comment
+  stripping, and the user's normal git hooks. Always go through
+  `git commit` so git stays in charge.
+- **Shell aliases don't apply inside the pane.** tmux runs commands
+  with `/bin/sh -c`. The wrapper resolves `nvim`/`vim` directly. If
+  nvim plugins still error, check that `nvim` is on `$PATH` in the
+  non-interactive shell — set it in `.zprofile`/`.zshenv`, not just
+  `.zshrc`.
+- **`remain-on-exit on`** would otherwise strand the pane after the
+  editor exits. The wrapper appends `tmux kill-pane` to defeat this.
+- **Empty / aborted message.** Git itself aborts the commit when the
+  message is empty (or unchanged from the template). The wrapper
+  doesn't need to do anything special.

--- a/agents/skills/edit-commit-message/git-editor.sh
+++ b/agents/skills/edit-commit-message/git-editor.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# git-editor.sh
+#
+# A GIT_EDITOR wrapper that opens the file git hands it (usually
+# COMMIT_EDITMSG, but also MERGE_MSG, rebase todo lists, etc.) in
+# nvim inside a new tmux pane, and blocks until the user closes it.
+#
+# Usage:
+#   GIT_EDITOR=/abs/path/to/git-editor.sh git commit
+#   GIT_EDITOR=/abs/path/to/git-editor.sh git commit --amend
+#   GIT_EDITOR=/abs/path/to/git-editor.sh git rebase -i HEAD~3
+#
+# Git itself takes care of:
+#   - including the diff (when commit.verbose=true or `git commit -v`)
+#   - stripping `#` comment lines
+#   - aborting on empty messages
+# so this script just has to "be the editor".
+
+set -euo pipefail
+
+FILE="${1:-}"
+if [ -z "$FILE" ]; then
+  echo "git-editor.sh: missing file argument" >&2
+  exit 2
+fi
+
+if [ -z "${TMUX:-}" ]; then
+  echo "git-editor.sh: not inside a tmux session, cannot open editor pane" >&2
+  echo "Start the agent (or git command) from inside tmux, or unset GIT_EDITOR." >&2
+  exit 1
+fi
+
+# Pick an editor. Don't recurse through $EDITOR/$VISUAL since this
+# script may itself be one of those. tmux runs the pane command via
+# /bin/sh -c which doesn't read shell aliases, so resolve concretely.
+if command -v nvim >/dev/null 2>&1; then
+  ED=nvim
+else
+  ED=vim
+fi
+
+DONE="$FILE.agent-done"
+rm -f "$DONE"
+
+# Split a new pane running the editor. After the editor exits:
+#   - `touch $DONE`  signals the waiter (normal exit path)
+#   - `tmux kill-pane` forces the pane to close even when the user
+#     has `set -g remain-on-exit on` in their tmux config
+PANE=$(tmux split-window -P -F '#{pane_id}' -v \
+  "$ED '$FILE'; touch '$DONE'; tmux kill-pane")
+
+# Wait until the editor is done. Two exit conditions:
+#   1. sentinel file appears -> normal `:wq` / `:q` exit
+#   2. pane disappears without the sentinel -> someone killed the
+#      pane externally; treat as abort, git will see an unchanged
+#      file and abort the commit on its own.
+while [ ! -f "$DONE" ]; do
+  if ! tmux display-message -p -t "$PANE" '#{pane_id}' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.3
+done
+
+rm -f "$DONE"

--- a/agents/skills/executing-plans/SKILL.md
+++ b/agents/skills/executing-plans/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: executing-plans
+description: Executes an implementation plan in batches with human checkpoints between each batch. Use when a plan exists and should be worked through with periodic human review rather than full automation. Triggers on "execute this plan", "work through the plan", "implement step by step", or when the user wants to be involved at each checkpoint rather than letting it run fully autonomous. Prefer subagent-driven-development for full task-by-task review; use this when batch checkpoints are preferred.
+---
+
+# Executing Plans
+
+**Announce:** "I'm using the executing-plans skill. I'll work through the plan in batches and check in with you between each."
+
+## Setup
+
+Before starting:
+1. Confirm which plan file to use
+2. Confirm batch size (default: 3 tasks per batch, or natural groupings)
+3. Confirm the test command to run between batches
+
+## The Batch Loop
+
+### Start of Each Batch
+
+Show the user which tasks are in this batch:
+```
+Batch [N] — Tasks [X–Y]:
+- Task X: [name]
+- Task X+1: [name]
+- Task Y: [name]
+
+Starting...
+```
+
+### Work Through the Batch
+
+For each task:
+- Implement it following TDD (write test first)
+- Verify tests pass
+- Commit
+
+### End of Batch Checkpoint
+
+After completing the batch, run the full test suite, then report:
+
+```
+Batch [N] complete ✅
+
+Tasks done:
+- [X]: [brief description of what was implemented]
+- [X+1]: [brief description]
+- [Y]: [brief description]
+
+Tests: [N passing, 0 failing]
+Commits: [N]
+
+Issues encountered: [none / description of any deviations]
+
+Next batch: Tasks [A–B] — [brief description]
+Continue?
+```
+
+**Wait for user confirmation before the next batch.**
+
+## Handling Problems Mid-Batch
+
+If a task hits a blocker:
+1. Complete any tasks in the batch that don't depend on the blocked task
+2. Report the blocker clearly at the checkpoint
+3. Propose options before proceeding
+
+## Tracking Progress
+
+Maintain a running summary using the plan's checkbox syntax:
+```
+- [x] Task 1: Done
+- [x] Task 2: Done
+- [ ] Task 3: In progress (current batch)
+- [ ] Task 4: Pending
+```
+
+Show this at each checkpoint so the user can see where you are.
+
+## Checklist for Completion
+
+- [ ] All tasks checked off
+- [ ] Full test suite passing
+- [ ] No skipped tasks without user sign-off
+- [ ] Proceed to finishing-a-development-branch

--- a/agents/skills/finishing-a-development-branch/SKILL.md
+++ b/agents/skills/finishing-a-development-branch/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: finishing-a-development-branch
+description: Guides the process of completing a feature branch — verifying tests, choosing merge/PR/keep/discard, and cleaning up the worktree. Use when all tasks on a feature branch are done, or when the user says "I'm done", "ready to merge", "wrap this up", or "finish the branch". Always verify tests pass and get an explicit merge decision before cleanup.
+---
+
+# Finishing a Development Branch
+
+**Announce:** "I'm using the finishing-a-development-branch skill."
+
+## Step 1: Final Verification
+
+Before anything else, confirm the branch is actually done:
+
+```bash
+# All tests pass?
+[your test command]
+
+# Any uncommitted changes?
+git status
+
+# Review what changed
+git diff main...HEAD --stat
+git log main..HEAD --oneline
+```
+
+If tests are failing: **do not proceed**. Fix the failures first.
+
+## Step 2: Self-Review
+
+Read through the diff with fresh eyes:
+
+```bash
+git diff main...HEAD
+```
+
+Ask:
+- Does this match the spec/plan?
+- Any debug code, TODOs, or print statements left in?
+- Any files accidentally modified?
+
+## Step 3: Choose a Path
+
+Present these options to the user:
+
+**A) Merge directly**
+```bash
+cd ../project-main
+git merge feature/feature-name
+git worktree remove ../project-feature-name
+git branch -d feature/feature-name
+```
+
+**B) Open a Pull Request**
+```bash
+git push origin feature/feature-name
+# Then open PR via GitHub/GitLab/etc.
+# Worktree stays until PR is merged
+```
+
+**C) Keep branch, not merging yet**
+```bash
+git push origin feature/feature-name
+# Worktree can stay or be removed
+git worktree remove ../project-feature-name  # optional
+```
+
+**D) Discard the work**
+```bash
+cd ../project-main
+git worktree remove ../project-feature-name
+git branch -D feature/feature-name  # -D forces deletion
+```
+
+## Step 4: Cleanup
+
+After merge (options A or after B's PR merges):
+
+```bash
+# Remove the worktree directory
+git worktree remove ../project-feature-name
+
+# Delete the local branch
+git branch -d feature/feature-name
+
+# Optionally delete remote branch
+git push origin --delete feature/feature-name
+```
+
+## Checklist
+
+- [ ] All tests passing
+- [ ] No uncommitted changes
+- [ ] Diff reviewed against spec
+- [ ] Merge decision made and executed
+- [ ] Worktree and branch cleaned up

--- a/agents/skills/frontend-design/SKILL.md
+++ b/agents/skills/frontend-design/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: frontend-design
+description: "Design and implement distinctive, production-ready frontend interfaces with strong aesthetic direction. Use when asked to create or restyle web pages, components, or applications (HTML/CSS/JS, React, Vue, etc.)."
+---
+
+# Frontend Design Skill
+
+Design and implement memorable frontend interfaces with a clear, intentional aesthetic. The output must be real, working code — not just mood boards. This skill is about **design thinking + execution**: every visual choice should be rooted in purpose and context.
+
+## When to Use
+
+Use this skill when the user wants to:
+- Create a new web page, landing page, dashboard, or app UI
+- Design or redesign frontend components or screens
+- Improve typography, layout, color, motion, or overall visual polish
+- Convert a concept or brief into a high‑fidelity, coded interface
+
+## Inputs to Gather (or Assume)
+
+Before coding, identify:
+- **Purpose & audience**: What problem does this UI solve? Who uses it?
+- **Brand/voice**: Any reference brands, tone, or visual inspiration?
+- **Technical constraints**: Framework, library, CSS strategy, accessibility, performance
+- **Content constraints**: Required copy, assets, data, features
+
+If the user did not provide this, ask **2–4 targeted questions**, or state reasonable assumptions in a short preface.
+
+## Design Thinking (Required)
+
+Commit to a **single, bold aesthetic direction**. Name it and execute it consistently. Examples:
+- Brutalist / raw / utilitarian
+- Editorial / magazine / typographic
+- Luxury / refined / minimal
+- Retro‑futuristic / cyber / neon
+- Art‑deco / geometric / ornamental
+- Handcrafted / organic / textured
+
+**Avoid generic AI aesthetics.** No “default” fonts, color schemes, or stock layouts.
+
+Before writing code, define the system:
+1. **Visual direction** — one sentence that describes the vibe
+2. **Differentiator** — what should be memorable about this UI?
+3. **Typography system** — display + body fonts, scale, weight, casing
+4. **Color system** — dominant, accent, neutral; define as CSS variables
+5. **Layout strategy** — grid rhythm, spacing scale, hierarchy plan
+6. **Motion strategy** — 1–2 meaningful interaction moments
+
+If the user wants code only, skip the explanation but still follow this internally.
+
+## Implementation Principles
+
+- **Working code**: HTML/CSS/JS or framework code that runs as‑is
+- **Semantic & accessible**: headings, labels, focus states, keyboard nav
+- **Responsive**: fluid layouts, breakpoints, responsive typography
+- **Tokenized styling**: CSS variables for colors, spacing, radii, shadows
+- **Modern layout**: prefer CSS Grid/Flex, avoid brittle positioning hacks
+
+## Aesthetic Guidelines
+
+### Typography
+- Typography should define the voice of the design
+- Avoid default fonts (Inter, Roboto, Arial, system stacks)
+- Use a **distinct display font** + a **refined body font**
+- Implement a clear hierarchy (size, weight, spacing, casing)
+
+### Color & Theme
+- Commit to a palette with a strong point‑of‑view
+- Avoid timid, overused gradients (e.g., purple‑to‑pink on white)
+- Use contrast intentionally and check legibility
+
+### Composition & Layout
+- Encourage asymmetry, scale contrast, overlap, or grid breaks
+- Use negative space deliberately (or controlled density if maximalist)
+- Create visual rhythm and hierarchy through spacing and alignment
+
+### Detail & Atmosphere
+- Add texture or depth when appropriate (noise, grain, subtle patterns)
+- Use shadows/glows only when they serve the concept
+- Consider unique borders, masks, or clip‑paths for distinct shapes
+
+### Motion & Interaction
+- Use motion sparingly but meaningfully
+- Favor one standout interaction over many tiny ones
+- Honor `prefers-reduced-motion`
+
+## Avoid
+
+- Cookie‑cutter hero + 3 card layouts
+- Generic gradients and default font choices
+- Unmotivated decorative elements
+- Overly flat, characterless component libraries
+
+## Deliverables
+
+- Provide full code with file names or component boundaries
+- Make customization easy with CSS variables or config objects
+- If assets are needed, provide inline SVGs or generative CSS patterns
+
+## Quality Checklist (Self‑validate)
+
+- Aesthetic direction is unmistakable
+- Typography feels intentional and expressive
+- Layout and spacing are consistent and purposeful
+- Color palette feels cohesive and legible
+- Interactions enhance the experience without clutter
+- Code runs as provided and is production‑ready
+
+**Remember:** a design is only as strong as its commitment. Choose a direction and execute it relentlessly.

--- a/agents/skills/github/SKILL.md
+++ b/agents/skills/github/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: github
+description: "Interact with GitHub using the `gh` CLI. Use `gh issue`, `gh pr`, `gh run`, and `gh api` for issues, PRs, CI runs, and advanced queries."
+---
+
+# GitHub Skill
+
+Use the `gh` CLI to interact with GitHub. Always specify `--repo owner/repo` when not in a git directory, or use URLs directly.
+
+## Pull Requests
+
+Check CI status on a PR:
+```bash
+gh pr checks 55 --repo owner/repo
+```
+
+List recent workflow runs:
+```bash
+gh run list --repo owner/repo --limit 10
+```
+
+View a run and see which steps failed:
+```bash
+gh run view <run-id> --repo owner/repo
+```
+
+View logs for failed steps only:
+```bash
+gh run view <run-id> --repo owner/repo --log-failed
+```
+
+## API for Advanced Queries
+
+The `gh api` command is useful for accessing data not available through other subcommands.
+
+Get PR with specific fields:
+```bash
+gh api repos/owner/repo/pulls/55 --jq '.title, .state, .user.login'
+```
+
+## JSON Output
+
+Most commands support `--json` for structured output.  You can use `--jq` to filter:
+
+```bash
+gh issue list --repo owner/repo --json number,title --jq '.[] | "\(.number): \(.title)"'
+```

--- a/agents/skills/google-workspace/SKILL.md
+++ b/agents/skills/google-workspace/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: google-workspace
+description: "Access Google Workspace APIs (Drive, Docs, Calendar, Gmail, Sheets, Slides, Chat, People) via local helper scripts without MCP. Handles OAuth login and direct API calls."
+---
+
+# Google Workspace
+
+Use this skill for Google Workspace tasks (Gmail, Drive, Calendar, Docs, Sheets, etc.).
+
+## Files
+
+- `scripts/auth.js` — OAuth login/status/clear + account enumeration
+- `scripts/workspace.js` — JavaScript execution based API runner
+
+## Account model (multi-account)
+
+This skill is **profile-based by email address**.
+
+- There is **no default account**.
+- Every API call must specify `--email <account@example.com>`.
+- Tokens are stored per-email under `~/.pi/google-workspace/tokens/`.
+
+Before running API calls, discover available signed-in accounts:
+
+```bash
+node scripts/auth.js accounts
+```
+
+## Usage
+
+Always use `exec` and always provide `--email`.
+
+```bash
+node scripts/workspace.js exec --email user@example.com <<'JS'
+const me = await workspace.whoAmI();
+const files = await workspace.call('drive', 'files.list', {
+  pageSize: 5,
+  fields: 'files(id,name,mimeType)',
+});
+return { me, files: files.files };
+JS
+```
+
+Available inside exec scripts:
+
+- `auth` (authorized OAuth client)
+- `google` (`googleapis` root)
+- `workspace.accountEmail` (selected profile email)
+- `workspace.call(service, methodPath, params, {version})`
+- `workspace.service(service, {version})`
+- `workspace.whoAmI()`
+
+Optional flags:
+
+- `--timeout <ms>` (default 30000, max 300000)
+- `--scopes s1,s2`
+- `--script 'return 42'`
+
+## Agent guidance
+
+1. Prefer one `exec` script per user request.
+2. Keep payloads small (`fields`, `maxResults`, minimal props).
+3. Use `Promise.all` for independent requests.
+4. Never print token contents.
+5. If the user did not specify an account, run `node scripts/auth.js accounts` and choose/confirm an explicit email.
+6. If auth fails, first run `node scripts/auth.js accounts` to see known profiles.
+7. If account mismatch is possible, run `workspace.whoAmI()` in the selected profile.
+8. On 401/403/unauthorized errors, switch account (`--email ...`) or re-login that specific profile.
+
+## Unauthorized/account-switch playbook
+
+If a request fails with unauthorized/forbidden/insufficient permissions:
+
+1. Enumerate profiles:
+
+```bash
+node scripts/auth.js accounts
+```
+
+2. Retry with the intended account:
+
+```bash
+node scripts/workspace.js exec --email correct-user@example.com <<'JS'
+return await workspace.whoAmI();
+JS
+```
+
+3. If token is stale or missing scopes, re-login that account:
+
+```bash
+node scripts/auth.js login --email correct-user@example.com
+```
+
+4. Retry the original request with the same `--email`.
+
+## Short Gmail counting example
+
+```bash
+node scripts/workspace.js exec --email user@example.com <<'JS'
+const gmail = google.gmail({ version: 'v1', auth });
+
+let trash = 0;
+let pageToken;
+do {
+  const res = await gmail.users.messages.list({
+    userId: 'me',
+    q: 'in:trash',
+    maxResults: 500,
+    pageToken,
+    fields: 'messages/id,nextPageToken',
+  });
+  trash += (res.data.messages || []).length;
+  pageToken = res.data.nextPageToken;
+} while (pageToken);
+
+return { currentlyInTrash: trash };
+JS
+```
+
+## Setup + auth
+
+```bash
+node scripts/auth.js login --email user@example.com
+```
+
+Notes:
+
+- Dependencies auto-install on first run.
+- Default auth mode is **cloud** (no local `credentials.json` needed).
+- Optional local mode: `GOOGLE_WORKSPACE_AUTH_MODE=local` and credentials at `~/.pi/google-workspace/credentials.json`.
+- Useful diagnostics:
+
+```bash
+node scripts/auth.js accounts
+node scripts/auth.js status --email user@example.com
+node scripts/auth.js clear --email user@example.com
+```

--- a/agents/skills/google-workspace/package-lock.json
+++ b/agents/skills/google-workspace/package-lock.json
@@ -1,0 +1,1401 @@
+{
+  "name": "google-workspace-skill",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "google-workspace-skill",
+      "dependencies": {
+        "@google-cloud/local-auth": "^3.0.1",
+        "googleapis": "^171.0.0"
+      }
+    },
+    "node_modules/@google-cloud/local-auth": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/local-auth/-/local-auth-3.0.1.tgz",
+      "integrity": "sha512-YJ3GFbksfHyEarbVHPSCzhKpjbnlAhdzg2SEf79l6ODukrSM1qUOqfopY232Xkw26huKSndyzmJz+A6b2WYn7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.1",
+        "google-auth-library": "^9.0.0",
+        "open": "^7.0.3",
+        "server-destroy": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "171.4.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.4.0.tgz",
+      "integrity": "sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/googleapis/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/agents/skills/google-workspace/package.json
+++ b/agents/skills/google-workspace/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "google-workspace-skill",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "@google-cloud/local-auth": "^3.0.1",
+    "googleapis": "^171.0.0"
+  }
+}

--- a/agents/skills/google-workspace/scripts/auth.js
+++ b/agents/skills/google-workspace/scripts/auth.js
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+
+const {
+  CREDENTIALS_PATH,
+  TOKENS_DIR,
+  DEFAULT_SCOPES,
+  authorize,
+  clearToken,
+  credentialsExist,
+  formatScopes,
+  getWorkspaceClientConfig,
+  listAccounts,
+  loadToken,
+  normalizeEmail,
+  resolveAuthMode,
+  tokenPathForEmail,
+} = require('./common');
+
+function printHelp() {
+  console.log(`Google Workspace auth helper
+
+Usage:
+  node scripts/auth.js login --email user@example.com [--scopes scope1,scope2,...]
+  node scripts/auth.js status --email user@example.com
+  node scripts/auth.js clear --email user@example.com
+  node scripts/auth.js accounts
+
+Environment overrides:
+  GOOGLE_WORKSPACE_CONFIG_DIR
+  GOOGLE_WORKSPACE_CREDENTIALS
+  GOOGLE_WORKSPACE_TOKENS_DIR
+  GOOGLE_WORKSPACE_AUTH_MODE            (local|cloud)
+  GOOGLE_WORKSPACE_CLIENT_ID            (cloud mode)
+  GOOGLE_WORKSPACE_CLOUD_FUNCTION_URL   (cloud mode)
+`);
+}
+
+function parseScopes(args) {
+  const idx = args.indexOf('--scopes');
+  if (idx === -1) {
+    return DEFAULT_SCOPES;
+  }
+
+  const raw = args[idx + 1];
+  if (!raw) {
+    throw new Error('--scopes requires a value');
+  }
+
+  const scopes = formatScopes(raw);
+  if (scopes.length === 0) {
+    throw new Error('--scopes produced an empty scope list');
+  }
+  return scopes;
+}
+
+function parseRequiredEmail(args) {
+  const idx = args.indexOf('--email');
+  if (idx === -1) {
+    throw new Error('Missing required --email <account@example.com>');
+  }
+
+  const raw = args[idx + 1];
+  if (!raw) {
+    throw new Error('--email requires a value');
+  }
+
+  return normalizeEmail(raw);
+}
+
+async function doLogin(args) {
+  const email = parseRequiredEmail(args);
+  const scopes = parseScopes(args);
+
+  await authorize({ email, scopes, interactive: true });
+
+  console.log('✅ Login successful. Token stored at:');
+  console.log(`   ${tokenPathForEmail(email)}`);
+}
+
+function printTokenDetails(token) {
+  const now = Date.now();
+  const expiry = token.expiry_date || null;
+  const expired = expiry ? expiry < now : null;
+  const scopeCount = formatScopes(token.scope).length;
+
+  console.log('Token details:');
+  console.log(`  access_token: ${token.access_token ? 'present' : 'missing'}`);
+  console.log(`  refresh_token: ${token.refresh_token ? 'present' : 'missing'}`);
+  console.log(`  scopes: ${scopeCount}`);
+
+  if (expiry) {
+    console.log(`  expiry_date: ${new Date(expiry).toISOString()}`);
+    console.log(`  expired: ${expired ? 'yes' : 'no'}`);
+  } else {
+    console.log('  expiry_date: n/a');
+  }
+}
+
+function doStatus(args) {
+  const email = parseRequiredEmail(args);
+
+  console.log('Credentials file:');
+  console.log(`  ${CREDENTIALS_PATH}`);
+  console.log(`  Exists: ${credentialsExist() ? 'yes' : 'no'}`);
+
+  const token = loadToken(email);
+  const mode = resolveAuthMode(token);
+  const workspaceCfg = getWorkspaceClientConfig();
+
+  console.log('\nSelected account:');
+  console.log(`  ${email}`);
+
+  console.log('\nAuth mode:');
+  console.log(`  ${mode}`);
+  if (mode === 'cloud') {
+    const maskedClientId = workspaceCfg.clientId.replace(/^[^-]+/, '***');
+    console.log(`  clientId: ${maskedClientId}`);
+    console.log(`  cloudFunctionUrl: ${workspaceCfg.cloudFunctionUrl}`);
+  }
+
+  console.log('\nToken file:');
+  console.log(`  ${tokenPathForEmail(email)}`);
+  console.log(`  Exists: ${token ? 'yes' : 'no'}`);
+
+  if (!token) {
+    console.log('\nTip: sign in with:');
+    console.log(`  node scripts/auth.js login --email ${email}`);
+    return;
+  }
+
+  console.log('');
+  printTokenDetails(token);
+}
+
+function doAccounts() {
+  const accounts = listAccounts();
+
+  console.log('Token store:');
+  console.log(`  ${TOKENS_DIR}`);
+
+  if (accounts.length === 0) {
+    console.log('\nNo signed-in accounts found.');
+    return;
+  }
+
+  console.log(`\nSigned-in accounts (${accounts.length}):`);
+
+  for (const account of accounts) {
+    console.log('');
+    console.log(`- email: ${account.email || '(unknown)'}`);
+    console.log(`  tokenFile: ${account.path}`);
+
+    if (account.error) {
+      console.log(`  error: ${account.error}`);
+      continue;
+    }
+
+    console.log(`  authMode: ${account.authMode || 'unknown'}`);
+    console.log(`  access_token: ${account.hasAccessToken ? 'present' : 'missing'}`);
+    console.log(`  refresh_token: ${account.hasRefreshToken ? 'present' : 'missing'}`);
+    console.log(`  scopes: ${account.scopes.length}`);
+
+    if (account.expiryDate) {
+      console.log(`  expiry_date: ${new Date(account.expiryDate).toISOString()}`);
+      console.log(`  expired: ${account.expired ? 'yes' : 'no'}`);
+    } else {
+      console.log('  expiry_date: n/a');
+    }
+  }
+}
+
+function doClear(args) {
+  const email = parseRequiredEmail(args);
+  clearToken(email);
+  console.log(`✅ Token cleared for ${email}.`);
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+
+  if (!command || command === 'help' || command === '--help' || command === '-h') {
+    printHelp();
+    return;
+  }
+
+  if (command === 'login') {
+    await doLogin(args);
+    return;
+  }
+
+  if (command === 'status') {
+    doStatus(args);
+    return;
+  }
+
+  if (command === 'accounts') {
+    doAccounts();
+    return;
+  }
+
+  if (command === 'clear') {
+    doClear(args);
+    return;
+  }
+
+  throw new Error(`Unknown command: ${command}`);
+}
+
+main().catch((error) => {
+  console.error(`❌ ${error.message}`);
+  process.exit(1);
+});

--- a/agents/skills/google-workspace/scripts/common.js
+++ b/agents/skills/google-workspace/scripts/common.js
@@ -1,0 +1,715 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const http = require('node:http');
+const net = require('node:net');
+const crypto = require('node:crypto');
+const { spawn, spawnSync } = require('node:child_process');
+
+const CONFIG_DIR =
+  process.env.GOOGLE_WORKSPACE_CONFIG_DIR ||
+  path.join(os.homedir(), '.pi', 'google-workspace');
+
+const CREDENTIALS_PATH =
+  process.env.GOOGLE_WORKSPACE_CREDENTIALS ||
+  path.join(CONFIG_DIR, 'credentials.json');
+
+const TOKENS_DIR =
+  process.env.GOOGLE_WORKSPACE_TOKENS_DIR || path.join(CONFIG_DIR, 'tokens');
+
+const SKILL_ROOT = path.join(__dirname, '..');
+
+const DEFAULT_CLIENT_ID =
+  '338689075775-o75k922vn5fdl18qergr96rp8g63e4d7.apps.googleusercontent.com';
+const DEFAULT_CLOUD_FUNCTION_URL =
+  'https://google-workspace-extension.geminicli.com';
+
+const REQUIRED_IDENTITY_SCOPES = [
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/userinfo.profile',
+];
+
+const DEFAULT_SCOPES = [
+  'https://www.googleapis.com/auth/documents',
+  'https://www.googleapis.com/auth/drive',
+  'https://www.googleapis.com/auth/calendar',
+  'https://www.googleapis.com/auth/chat.spaces',
+  'https://www.googleapis.com/auth/chat.messages',
+  'https://www.googleapis.com/auth/chat.memberships',
+  ...REQUIRED_IDENTITY_SCOPES,
+  'https://www.googleapis.com/auth/gmail.modify',
+  'https://www.googleapis.com/auth/directory.readonly',
+  'https://www.googleapis.com/auth/presentations.readonly',
+  'https://www.googleapis.com/auth/spreadsheets.readonly',
+];
+
+const DEFAULT_VERSIONS = {
+  calendar: 'v3',
+  chat: 'v1',
+  docs: 'v1',
+  drive: 'v3',
+  gmail: 'v1',
+  people: 'v1',
+  sheets: 'v4',
+  slides: 'v1',
+};
+
+let runtimeDeps;
+
+function ensureConfigDir() {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+}
+
+function ensureTokensDir() {
+  fs.mkdirSync(TOKENS_DIR, { recursive: true });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function installDependencies() {
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  console.error('ℹ️  Installing Google Workspace skill dependencies...');
+
+  const result = spawnSync(npm, ['install', '--no-audit', '--no-fund'], {
+    cwd: SKILL_ROOT,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to run npm install: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`npm install failed with exit code ${result.status}`);
+  }
+}
+
+function loadRuntimeDeps() {
+  if (runtimeDeps) {
+    return runtimeDeps;
+  }
+
+  try {
+    const { google } = require('googleapis');
+    const { authenticate } = require('@google-cloud/local-auth');
+    runtimeDeps = { google, authenticate };
+    return runtimeDeps;
+  } catch (error) {
+    if (error && error.code === 'MODULE_NOT_FOUND') {
+      installDependencies();
+      const { google } = require('googleapis');
+      const { authenticate } = require('@google-cloud/local-auth');
+      runtimeDeps = { google, authenticate };
+      return runtimeDeps;
+    }
+    throw error;
+  }
+}
+
+function getGoogleApis() {
+  return loadRuntimeDeps().google;
+}
+
+function getWorkspaceClientConfig() {
+  return {
+    clientId:
+      process.env.GOOGLE_WORKSPACE_CLIENT_ID ||
+      process.env.WORKSPACE_CLIENT_ID ||
+      DEFAULT_CLIENT_ID,
+    cloudFunctionUrl:
+      process.env.GOOGLE_WORKSPACE_CLOUD_FUNCTION_URL ||
+      process.env.WORKSPACE_CLOUD_FUNCTION_URL ||
+      DEFAULT_CLOUD_FUNCTION_URL,
+  };
+}
+
+function credentialsExist() {
+  return fs.existsSync(CREDENTIALS_PATH);
+}
+
+function normalizeEmail(email) {
+  const normalized = String(email || '').trim().toLowerCase();
+  if (!normalized) {
+    throw new Error('Email is required. Pass --email <account@example.com>.');
+  }
+
+  if (!/^[^@\s]+@[^@\s]+$/.test(normalized)) {
+    throw new Error(`Invalid email address: ${email}`);
+  }
+
+  return normalized;
+}
+
+function tokenFilenameForEmail(email) {
+  return `${encodeURIComponent(normalizeEmail(email))}.json`;
+}
+
+function tokenPathForEmail(email) {
+  return path.join(TOKENS_DIR, tokenFilenameForEmail(email));
+}
+
+function tokenExists(email) {
+  return fs.existsSync(tokenPathForEmail(email));
+}
+
+function loadCredentialsFile() {
+  if (!credentialsExist()) {
+    throw new Error(
+      `Missing OAuth credentials file at ${CREDENTIALS_PATH}. ` +
+        'Create a Google OAuth Desktop client and save the JSON there.',
+    );
+  }
+  return readJson(CREDENTIALS_PATH);
+}
+
+function loadToken(email) {
+  const tokenPath = tokenPathForEmail(email);
+  if (!fs.existsSync(tokenPath)) {
+    return null;
+  }
+  return readJson(tokenPath);
+}
+
+function decodeEmailFromTokenFilename(filename) {
+  if (!filename.endsWith('.json')) {
+    return null;
+  }
+
+  try {
+    return normalizeEmail(decodeURIComponent(filename.slice(0, -5)));
+  } catch {
+    return null;
+  }
+}
+
+function listAccounts() {
+  if (!fs.existsSync(TOKENS_DIR)) {
+    return [];
+  }
+
+  const results = [];
+  const entries = fs.readdirSync(TOKENS_DIR, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) {
+      continue;
+    }
+
+    const tokenPath = path.join(TOKENS_DIR, entry.name);
+    const emailFromFilename = decodeEmailFromTokenFilename(entry.name);
+
+    let token;
+    try {
+      token = readJson(tokenPath);
+    } catch (error) {
+      results.push({
+        email: emailFromFilename,
+        path: tokenPath,
+        error: `Failed to read token JSON: ${error.message}`,
+      });
+      continue;
+    }
+
+    let email = emailFromFilename;
+    if (token && token.__email) {
+      try {
+        email = normalizeEmail(token.__email);
+      } catch {
+        // Ignore malformed __email metadata and keep filename-derived email.
+      }
+    }
+
+    const expiryDate = token.expiry_date || null;
+
+    results.push({
+      email,
+      path: tokenPath,
+      authMode: token.__authMode === 'local' || token.__authMode === 'cloud'
+        ? token.__authMode
+        : null,
+      hasAccessToken: Boolean(token.access_token),
+      hasRefreshToken: Boolean(token.refresh_token),
+      scopes: formatScopes(token.scope),
+      expiryDate,
+      expired: expiryDate ? expiryDate < Date.now() : null,
+    });
+  }
+
+  return results.sort((a, b) => {
+    const left = a.email || '';
+    const right = b.email || '';
+    return left.localeCompare(right);
+  });
+}
+
+function createOAuthClientFromCredentials(credentialsJson) {
+  const creds = credentialsJson.installed || credentialsJson.web;
+  if (!creds) {
+    throw new Error(
+      'Invalid credentials.json: expected an "installed" or "web" key.',
+    );
+  }
+
+  if (!creds.client_id || !creds.client_secret) {
+    throw new Error(
+      'Invalid credentials.json: missing client_id or client_secret.',
+    );
+  }
+
+  const redirectUri = Array.isArray(creds.redirect_uris)
+    ? creds.redirect_uris[0]
+    : undefined;
+
+  const google = getGoogleApis();
+  return new google.auth.OAuth2(
+    creds.client_id,
+    creds.client_secret,
+    redirectUri || 'http://localhost',
+  );
+}
+
+function createCloudOAuthClient() {
+  const google = getGoogleApis();
+  const { clientId } = getWorkspaceClientConfig();
+  return new google.auth.OAuth2({ clientId });
+}
+
+function resolveAuthMode(token) {
+  const forced = process.env.GOOGLE_WORKSPACE_AUTH_MODE;
+  if (forced === 'local' || forced === 'cloud') {
+    return forced;
+  }
+
+  if (token && (token.__authMode === 'local' || token.__authMode === 'cloud')) {
+    return token.__authMode;
+  }
+
+  if (credentialsExist()) {
+    return 'local';
+  }
+
+  return 'cloud';
+}
+
+function saveToken(email, token, mode) {
+  ensureConfigDir();
+  ensureTokensDir();
+
+  const normalizedEmail = normalizeEmail(email);
+  const tokenPath = tokenPathForEmail(normalizedEmail);
+
+  const payload = {
+    ...token,
+    __authMode: mode,
+    __email: normalizedEmail,
+  };
+
+  fs.writeFileSync(tokenPath, JSON.stringify(payload, null, 2));
+  try {
+    fs.chmodSync(tokenPath, 0o600);
+  } catch {
+    // Non-POSIX file systems can fail chmod. Ignore.
+  }
+}
+
+function clearToken(email) {
+  const tokenPath = tokenPathForEmail(email);
+  if (fs.existsSync(tokenPath)) {
+    fs.rmSync(tokenPath);
+  }
+}
+
+function isExpiringSoon(credentials) {
+  if (!credentials || !credentials.expiry_date) {
+    return false;
+  }
+  return credentials.expiry_date < Date.now() + 60_000;
+}
+
+function openUrlInBrowser(targetUrl) {
+  let command;
+  let args;
+
+  if (process.platform === 'darwin') {
+    command = 'open';
+    args = [targetUrl];
+  } else if (process.platform === 'win32') {
+    command = 'cmd';
+    args = ['/c', 'start', '', targetUrl];
+  } else {
+    command = 'xdg-open';
+    args = [targetUrl];
+  }
+
+  const child = spawn(command, args, {
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+}
+
+function getAvailablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, () => {
+      const address = server.address();
+      const port = address && typeof address === 'object' ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+async function refreshViaCloudFunction(refreshToken) {
+  const { cloudFunctionUrl } = getWorkspaceClientConfig();
+
+  const response = await fetch(`${cloudFunctionUrl}/refreshToken`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Cloud token refresh failed: ${response.status} ${body}`);
+  }
+
+  return response.json();
+}
+
+function mergeWithIdentityScopes(scopes) {
+  return Array.from(new Set([...formatScopes(scopes), ...REQUIRED_IDENTITY_SCOPES]));
+}
+
+async function fetchAuthenticatedEmail(authClient) {
+  const google = getGoogleApis();
+  const oauth2 = google.oauth2({ version: 'v2', auth: authClient });
+  const response = await oauth2.userinfo.get();
+  const email = response?.data?.email;
+  if (!email) {
+    throw new Error(
+      'Authentication succeeded, but Google did not return an email address. ' +
+        'Ensure userinfo.email scope is granted.',
+    );
+  }
+  return normalizeEmail(email);
+}
+
+async function ensureExpectedEmail(authClient, expectedEmail) {
+  const normalizedExpectedEmail = normalizeEmail(expectedEmail);
+  const authenticatedEmail = await fetchAuthenticatedEmail(authClient);
+
+  if (authenticatedEmail !== normalizedExpectedEmail) {
+    throw new Error(
+      `Authenticated as ${authenticatedEmail}, but expected ${normalizedExpectedEmail}. ` +
+        'Sign in with the requested account and retry.',
+    );
+  }
+
+  return authenticatedEmail;
+}
+
+async function interactiveLoginLocal(scopes, email) {
+  const { authenticate } = loadRuntimeDeps();
+  console.error('ℹ️  Opening browser for Google OAuth login (local credentials)...');
+
+  const authClient = await authenticate({
+    keyfilePath: CREDENTIALS_PATH,
+    scopes: mergeWithIdentityScopes(scopes),
+  });
+
+  if (!authClient.credentials || !authClient.credentials.access_token) {
+    throw new Error('Authentication failed: no access token returned.');
+  }
+
+  const normalizedEmail = await ensureExpectedEmail(authClient, email);
+  saveToken(normalizedEmail, authClient.credentials, 'local');
+  return authClient;
+}
+
+async function interactiveLoginCloud(scopes, email) {
+  const client = createCloudOAuthClient();
+  const { cloudFunctionUrl } = getWorkspaceClientConfig();
+
+  const host = process.env.GOOGLE_WORKSPACE_CALLBACK_HOST || 'localhost';
+  const port = await getAvailablePort();
+  const callbackUrl = `http://${host}:${port}/oauth2callback`;
+
+  const csrfToken = crypto.randomBytes(32).toString('hex');
+  const statePayload = {
+    uri: callbackUrl,
+    manual: false,
+    csrf: csrfToken,
+  };
+  const state = Buffer.from(JSON.stringify(statePayload), 'utf8').toString(
+    'base64',
+  );
+
+  const authUrl = client.generateAuthUrl({
+    redirect_uri: cloudFunctionUrl,
+    access_type: 'offline',
+    scope: mergeWithIdentityScopes(scopes),
+    state,
+    prompt: 'consent',
+  });
+
+  console.error('ℹ️  Opening browser for Google OAuth login...');
+  try {
+    openUrlInBrowser(authUrl);
+  } catch {
+    console.error('⚠️  Could not auto-open browser. Open this URL manually:');
+    console.error(authUrl);
+  }
+
+  const loginTimeoutMs = 5 * 60 * 1000;
+
+  const credentials = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      server.close(() => {
+        reject(
+          new Error(
+            'Authentication timed out after 5 minutes. Please try again.',
+          ),
+        );
+      });
+    }, loginTimeoutMs);
+
+    const server = http.createServer((req, res) => {
+      try {
+        if (!req.url || !req.url.startsWith('/oauth2callback')) {
+          res.statusCode = 404;
+          res.end('Not found');
+          return;
+        }
+
+        const parsed = new URL(req.url, `http://${host}:${port}`);
+        const returnedState = parsed.searchParams.get('state');
+        if (returnedState !== csrfToken) {
+          res.statusCode = 400;
+          res.end('State mismatch.');
+          clearTimeout(timer);
+          server.close(() => {
+            reject(new Error('OAuth state mismatch.'));
+          });
+          return;
+        }
+
+        const errorCode = parsed.searchParams.get('error');
+        if (errorCode) {
+          const description =
+            parsed.searchParams.get('error_description') ||
+            'No additional details';
+          res.statusCode = 400;
+          res.end('Authentication failed.');
+          clearTimeout(timer);
+          server.close(() => {
+            reject(new Error(`Google OAuth error: ${errorCode}. ${description}`));
+          });
+          return;
+        }
+
+        const accessToken = parsed.searchParams.get('access_token');
+        const refreshToken = parsed.searchParams.get('refresh_token');
+        const scope = parsed.searchParams.get('scope');
+        const tokenType = parsed.searchParams.get('token_type');
+        const expiryDateRaw = parsed.searchParams.get('expiry_date');
+
+        if (!accessToken || !expiryDateRaw) {
+          res.statusCode = 400;
+          res.end('Authentication failed: missing tokens.');
+          clearTimeout(timer);
+          server.close(() => {
+            reject(
+              new Error('Authentication failed: callback did not include tokens.'),
+            );
+          });
+          return;
+        }
+
+        const expiryDate = Number.parseInt(expiryDateRaw, 10);
+        if (Number.isNaN(expiryDate)) {
+          res.statusCode = 400;
+          res.end('Authentication failed: invalid expiry date.');
+          clearTimeout(timer);
+          server.close(() => {
+            reject(
+              new Error('Authentication failed: callback expiry_date is invalid.'),
+            );
+          });
+          return;
+        }
+
+        const creds = {
+          access_token: accessToken,
+          refresh_token: refreshToken || null,
+          scope: scope || undefined,
+          token_type: tokenType || undefined,
+          expiry_date: expiryDate,
+        };
+
+        res.end('Authentication successful. You can close this tab.');
+
+        clearTimeout(timer);
+        server.close(() => {
+          resolve(creds);
+        });
+      } catch (error) {
+        clearTimeout(timer);
+        server.close(() => {
+          reject(error);
+        });
+      }
+    });
+
+    server.on('error', (error) => {
+      clearTimeout(timer);
+      reject(new Error(`OAuth callback server error: ${error.message}`));
+    });
+
+    server.listen(port, host, () => {
+      // listener started
+    });
+  });
+
+  client.setCredentials(credentials);
+  const normalizedEmail = await ensureExpectedEmail(client, email);
+  saveToken(normalizedEmail, credentials, 'cloud');
+  return client;
+}
+
+async function interactiveLogin(scopes, mode, email) {
+  if (mode === 'local') {
+    return interactiveLoginLocal(scopes, email);
+  }
+  return interactiveLoginCloud(scopes, email);
+}
+
+function stripInternalTokenFields(token) {
+  if (!token || typeof token !== 'object') {
+    return token;
+  }
+  const clone = { ...token };
+  delete clone.__authMode;
+  delete clone.__email;
+  return clone;
+}
+
+async function authorize(options = {}) {
+  const email = normalizeEmail(options.email);
+  const scopes = mergeWithIdentityScopes(options.scopes || DEFAULT_SCOPES);
+  const interactive = options.interactive !== false;
+
+  ensureConfigDir();
+  ensureTokensDir();
+  loadRuntimeDeps();
+
+  const token = loadToken(email);
+  const mode = resolveAuthMode(token);
+
+  const client =
+    mode === 'local'
+      ? createOAuthClientFromCredentials(loadCredentialsFile())
+      : createCloudOAuthClient();
+
+  if (!token) {
+    if (!interactive) {
+      throw new Error(
+        `No token found for ${email} at ${tokenPathForEmail(email)}. ` +
+          `Run: node scripts/auth.js login --email ${email}`,
+      );
+    }
+    return interactiveLogin(scopes, mode, email);
+  }
+
+  if (token.__email) {
+    const tokenEmail = normalizeEmail(token.__email);
+    if (tokenEmail !== email) {
+      throw new Error(
+        `Token metadata mismatch. Requested ${email} but token is tagged as ${tokenEmail}. ` +
+          `Delete it and sign in again: node scripts/auth.js clear --email ${email}`,
+      );
+    }
+  }
+
+  client.setCredentials(stripInternalTokenFields(token));
+
+  if (!isExpiringSoon(client.credentials)) {
+    return client;
+  }
+
+  if (client.credentials.refresh_token) {
+    if (mode === 'local') {
+      const refreshed = await client.refreshAccessToken();
+      const merged = {
+        ...refreshed.credentials,
+        refresh_token:
+          refreshed.credentials.refresh_token || client.credentials.refresh_token,
+      };
+      client.setCredentials(merged);
+      saveToken(email, merged, 'local');
+      return client;
+    }
+
+    const refreshed = await refreshViaCloudFunction(
+      client.credentials.refresh_token,
+    );
+    const merged = {
+      ...refreshed,
+      refresh_token: client.credentials.refresh_token,
+    };
+    client.setCredentials(merged);
+    saveToken(email, merged, 'cloud');
+    return client;
+  }
+
+  if (!interactive) {
+    throw new Error(
+      `Token for ${email} is expired and no refresh token is available. ` +
+        `Run: node scripts/auth.js login --email ${email}`,
+    );
+  }
+
+  return interactiveLogin(scopes, mode, email);
+}
+
+function formatScopes(value) {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return String(value)
+    .split(/[\s,]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+module.exports = {
+  CONFIG_DIR,
+  CREDENTIALS_PATH,
+  TOKENS_DIR,
+  DEFAULT_SCOPES,
+  DEFAULT_VERSIONS,
+  REQUIRED_IDENTITY_SCOPES,
+  authorize,
+  clearToken,
+  credentialsExist,
+  formatScopes,
+  getGoogleApis,
+  getWorkspaceClientConfig,
+  listAccounts,
+  loadToken,
+  normalizeEmail,
+  resolveAuthMode,
+  tokenExists,
+  tokenPathForEmail,
+};

--- a/agents/skills/google-workspace/scripts/workspace.js
+++ b/agents/skills/google-workspace/scripts/workspace.js
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+
+const vm = require('node:vm');
+const util = require('node:util');
+
+const {
+  DEFAULT_VERSIONS,
+  authorize,
+  formatScopes,
+  getGoogleApis,
+  loadToken,
+  normalizeEmail,
+  resolveAuthMode,
+} = require('./common');
+
+function printHelp() {
+  console.log(`Google Workspace API helper (exec-only)
+
+Usage:
+  node scripts/workspace.js exec --email user@example.com [--script 'return 1'] [--timeout 30000] [--scopes s1,s2]
+
+Example:
+  node scripts/workspace.js exec --email user@example.com <<'JS'
+  const me = await workspace.whoAmI();
+  const files = await workspace.call('drive', 'files.list', {
+    pageSize: 3,
+    fields: 'files(id,name)'
+  });
+  return { me, files: files.files };
+  JS
+`);
+}
+
+function parseTimeout(raw) {
+  if (!raw) {
+    throw new Error('--timeout requires a value');
+  }
+
+  const numeric = Number(raw);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error('--timeout must be a positive number of milliseconds');
+  }
+
+  return Math.min(Math.floor(numeric), 5 * 60_000);
+}
+
+function parseOptions(argv) {
+  const positional = [];
+  const options = {
+    email: undefined,
+    scopes: undefined,
+    timeout: undefined,
+    script: undefined,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--email') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--email requires a value');
+      }
+      options.email = normalizeEmail(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--scopes') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('--scopes requires a value');
+      }
+      options.scopes = formatScopes(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--timeout') {
+      options.timeout = parseTimeout(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--script') {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        throw new Error('--script requires a value');
+      }
+      options.script = value;
+      i += 1;
+      continue;
+    }
+
+    positional.push(arg);
+  }
+
+  return { positional, options };
+}
+
+function resolveMethod(root, methodPath) {
+  const parts = methodPath.split('.').filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error('method.path is empty');
+  }
+
+  let parent = root;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    parent = parent?.[parts[i]];
+    if (!parent) {
+      throw new Error(`Invalid method path (missing segment: ${parts[i]})`);
+    }
+  }
+
+  const methodName = parts[parts.length - 1];
+  const method = parent?.[methodName];
+
+  if (typeof method !== 'function') {
+    throw new Error(
+      `Invalid method path: ${methodPath}. Final segment is not callable.`,
+    );
+  }
+
+  return { parent, method };
+}
+
+async function callApi({
+  service,
+  methodPath,
+  params,
+  version,
+  scopes,
+  authClient,
+  email,
+}) {
+  const google = getGoogleApis();
+  const factory = google[service];
+  if (typeof factory !== 'function') {
+    throw new Error(`Unknown Google API service: ${service}`);
+  }
+
+  const auth =
+    authClient ||
+    (await authorize({
+      email,
+      interactive: true,
+      scopes: scopes && scopes.length > 0 ? scopes : undefined,
+    }));
+
+  const api = factory({
+    version: version || DEFAULT_VERSIONS[service] || 'v1',
+    auth,
+  });
+
+  const { parent, method } = resolveMethod(api, methodPath);
+  const response = await method.call(parent, params || {});
+  return response?.data ?? response;
+}
+
+function getServiceClient({ google, auth, service, version }) {
+  const factory = google[service];
+  if (typeof factory !== 'function') {
+    throw new Error(`Unknown Google API service: ${service}`);
+  }
+
+  return factory({
+    version: version || DEFAULT_VERSIONS[service] || 'v1',
+    auth,
+  });
+}
+
+function createWorkspaceHelper({ auth, google, email }) {
+  return {
+    accountEmail: email,
+    versions: { ...DEFAULT_VERSIONS },
+
+    async call(service, methodPath, params = {}, options = {}) {
+      return callApi({
+        service,
+        methodPath,
+        params,
+        version: options.version,
+        authClient: auth,
+        email,
+      });
+    },
+
+    service(service, options = {}) {
+      return getServiceClient({
+        google,
+        auth,
+        service,
+        version: options.version,
+      });
+    },
+
+    async whoAmI() {
+      const oauth2 = google.oauth2({ version: 'v2', auth });
+      const response = await oauth2.userinfo.get();
+      return response?.data ?? response;
+    },
+  };
+}
+
+function formatLogArg(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return util.inspect(value, {
+    depth: 6,
+    maxArrayLength: 200,
+    breakLength: 120,
+    compact: 2,
+  });
+}
+
+function createExecutionConsole(logs) {
+  const write = (level, args) => {
+    logs.push({
+      level,
+      message: args.map(formatLogArg).join(' '),
+      timestamp: new Date().toISOString(),
+    });
+  };
+
+  return {
+    log: (...args) => write('log', args),
+    info: (...args) => write('info', args),
+    warn: (...args) => write('warn', args),
+    error: (...args) => write('error', args),
+    debug: (...args) => write('debug', args),
+  };
+}
+
+function normalizeForJson(value, seen = new WeakSet()) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'bigint') {
+    return `${value}n`;
+  }
+
+  if (typeof value === 'function') {
+    return `[Function ${value.name || 'anonymous'}]`;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeForJson(item, seen));
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+
+    const output = {};
+    for (const [key, nested] of Object.entries(value)) {
+      output[key] = normalizeForJson(nested, seen);
+    }
+    return output;
+  }
+
+  return value;
+}
+
+function withTimeout(promise, timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return promise;
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Execution timed out after ${Math.round(timeoutMs)}ms.`));
+    }, timeoutMs);
+
+    Promise.resolve(promise).then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function readStdinText() {
+  return new Promise((resolve, reject) => {
+    if (process.stdin.isTTY) {
+      resolve('');
+      return;
+    }
+
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+function createUnauthorizedHint(message, email) {
+  const msg = String(message || '').toLowerCase();
+  const looksUnauthorized =
+    msg.includes('401') ||
+    msg.includes('unauthorized') ||
+    msg.includes('invalid credentials') ||
+    msg.includes('insufficient permissions') ||
+    msg.includes('forbidden');
+
+  if (!looksUnauthorized) {
+    return null;
+  }
+
+  return [
+    `Auth/account hint: this request may not be authorized for ${email}.`,
+    'List known accounts with: node scripts/auth.js accounts',
+    `Sign in or refresh this account with: node scripts/auth.js login --email ${email}`,
+    'Then retry workspace.js exec with the intended --email.',
+  ].join(' ');
+}
+
+function errorPayload(error, logs, timeoutMs, email) {
+  const baseMessage = error?.message || String(error);
+  const hint = createUnauthorizedHint(baseMessage, email);
+
+  return {
+    ok: false,
+    timeoutMs,
+    logs,
+    error: {
+      name: error?.name || 'Error',
+      message: hint ? `${baseMessage}\n${hint}` : baseMessage,
+      stack: error?.stack || null,
+    },
+  };
+}
+
+async function cmdExec(args, options) {
+  if (!options.email) {
+    throw new Error(
+      'Missing required --email <account@example.com>. ' +
+        'Use node scripts/auth.js accounts to list known accounts.',
+    );
+  }
+
+  let script = options.script;
+
+  if (!script && args.length > 0) {
+    script = args.join(' ');
+  }
+
+  if (!script) {
+    script = await readStdinText();
+  }
+
+  script = String(script || '').trim();
+
+  if (!script) {
+    throw new Error(
+      'Usage: exec --email user@example.com [--script "..."] (or pipe script via stdin / heredoc)',
+    );
+  }
+
+  const timeoutMs = options.timeout || 30_000;
+  const logs = [];
+
+  try {
+    const auth = await authorize({
+      email: options.email,
+      interactive: true,
+      scopes: options.scopes && options.scopes.length > 0
+        ? options.scopes
+        : undefined,
+    });
+
+    const google = getGoogleApis();
+    const workspace = createWorkspaceHelper({ auth, google, email: options.email });
+
+    const context = vm.createContext({
+      Buffer,
+      URL,
+      URLSearchParams,
+      TextEncoder,
+      TextDecoder,
+      setTimeout,
+      clearTimeout,
+      console: createExecutionConsole(logs),
+      auth,
+      google,
+      workspace,
+    });
+
+    const wrappedScript = `
+(async () => {
+${script}
+})()
+`;
+
+    const compiled = new vm.Script(wrappedScript, {
+      filename: 'workspace-exec.js',
+      displayErrors: true,
+    });
+
+    const resultPromise = Promise.resolve(
+      compiled.runInContext(context, {
+        timeout: Math.min(timeoutMs, 60_000),
+        displayErrors: true,
+      }),
+    );
+
+    const result = await withTimeout(resultPromise, timeoutMs);
+    const token = loadToken(options.email);
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          email: options.email,
+          authMode: resolveAuthMode(token),
+          timeoutMs,
+          logs,
+          result: normalizeForJson(result),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    console.log(
+      JSON.stringify(
+        errorPayload(error, logs, timeoutMs, options.email),
+        null,
+        2,
+      ),
+    );
+    process.exitCode = 1;
+  }
+}
+
+async function main() {
+  const { positional, options } = parseOptions(process.argv.slice(2));
+  const [command, ...args] = positional;
+
+  if (
+    !command ||
+    command === 'help' ||
+    command === '--help' ||
+    command === '-h'
+  ) {
+    printHelp();
+    return;
+  }
+
+  if (command !== 'exec') {
+    throw new Error(`Unknown command: ${command}. Only 'exec' is supported.`);
+  }
+
+  await cmdExec(args, options);
+}
+
+main().catch((error) => {
+  console.error(`❌ ${error.message}`);
+  process.exit(1);
+});

--- a/agents/skills/live-preview/SKILL.md
+++ b/agents/skills/live-preview/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: live-preview
+description: "Launch a project's local dev server and drive it in a visible (headed) playwright-cli browser so the user can watch and interact alongside the agent. Use when asked to preview the site/app locally, open the page in a real browser, give UI/design feedback, or interactively click through a running dev build."
+---
+
+# Live preview
+
+Serve a project locally and open it in a **headed** playwright-cli session the
+user can see and click in, while the agent inspects and drives the same page.
+
+Builds on the `playwright-cli` skill — read that for the full command set. This
+skill is the recipe and the gotchas that make interactive local preview work.
+
+## The three gotchas (why naive attempts fail)
+
+1. **`playwright-cli open` is headless by default.** Without `--headed` the
+   browser is invisible and the user can't interact. Always pass `--headed`.
+2. **The dev server may already be running.** Starting a second one fails with
+   `EADDRINUSE`. If the expected port is already bound, assume the dev server
+   is up and skip starting it.
+
+3. **`open` must come before `show`/`snapshot`/`click`.** Use a **named**
+   session so the browser persists across turns.
+
+## Step 1 — Find the dev command and port
+
+Inspect the project to determine how it serves locally and on which port.
+Common sources:
+
+- `package.json` scripts: `dev`, `start`, `serve` (Vite → 5173, Next → 3000,
+  CRA → 3000, Astro → 4321).
+- `Makefile` / `Procfile` / `docker-compose.yml` targets.
+- A custom server file (e.g. `dev_server.js`) — grep it for the port.
+
+Set these for the snippets below:
+
+```bash
+PORT=5173                      # the port the dev server listens on
+DEV_CMD="npm run dev"          # the command that starts it
+URL="http://localhost:$PORT/"
+# Name the session after the project so parallel previews don't collide.
+# Prefer the git repo name, fall back to the current directory name.
+SESSION=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+```
+
+## Step 2 — Start (idempotent) and open headed
+
+```bash
+# If the expected port is already bound, assume the dev server is running and
+# leave it alone. Only start one when the port is free.
+if lsof -ti:"$PORT" >/dev/null 2>&1; then
+  echo "Port $PORT already bound — assuming the dev server is running."
+else
+  $DEV_CMD >/tmp/live-preview.log 2>&1 &
+  # Wait until the freshly started server answers (first build can take a bit)
+  until curl -sf -o /dev/null "$URL"; do sleep 1; done
+fi
+
+# Open a visible browser pointed at the local app
+playwright-cli -s="$SESSION" open "$URL" --headed
+```
+
+If the session is already open but headless, reopen it headed:
+
+```bash
+playwright-cli -s="$SESSION" close
+playwright-cli -s="$SESSION" open "$URL" --headed
+```
+
+Confirm with `playwright-cli list` — the session should show `headed: true`.
+
+## Step 3 — Interact
+
+```bash
+playwright-cli -s="$SESSION" snapshot          # inspect the page (get refs)
+playwright-cli -s="$SESSION" click e15         # act on a ref from the snapshot
+playwright-cli -s="$SESSION" reload            # refresh after an edit
+```
+
+For UI/design review, hand control to the user — they draw boxes and type
+notes, and you receive the annotated screenshot, region snapshot, and comments:
+
+```bash
+playwright-cli -s="$SESSION" show --annotate
+```
+
+## Step 4 — Edit-and-refresh loop
+
+If the dev server has live reload, the headed window updates itself after edits.
+Otherwise force it:
+
+```bash
+playwright-cli -s="$SESSION" reload
+```
+
+## Step 5 — Cleanup
+
+```bash
+playwright-cli -s="$SESSION" close   # close just this browser
+kill "$(lsof -ti:"$PORT")"           # stop the dev server on that port (if you started it)
+```
+
+## Troubleshooting
+
+- `EADDRINUSE` — the dev server is already up; skip starting it (the
+  port-bound check handles this).
+- `The browser '<session>' is not open` — run `open` first.
+- Invisible window / `headed: false` in `playwright-cli list` — you opened
+  headless; close and reopen with `--headed`.
+- Stale/zombie browsers — `playwright-cli close-all` or `playwright-cli kill-all`.

--- a/agents/skills/mermaid/SKILL.md
+++ b/agents/skills/mermaid/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: mermaid
+description: "Must read guide on creating/editing mermaid charts with valiation tools"
+---
+
+# Mermaid Skill
+
+Use this skill to quickly validate Mermaid diagrams by parsing + rendering them with the official Mermaid CLI.
+
+## Prerequisites
+
+- Node.js + npm (for `npx`).
+- First run downloads a headless Chromium via Puppeteer. If Chromium is missing, set `PUPPETEER_EXECUTABLE_PATH`.
+
+## Tool
+
+### Validate a diagram
+
+```bash
+./tools/validate.sh diagram.mmd [output.svg]
+```
+
+- Parses and renders the Mermaid source.
+- Non-zero exit = invalid Mermaid syntax.
+- Prints an ASCII preview using `beautiful-mermaid` (best-effort; not all diagram types are supported).
+- If `output.svg` is omitted, the SVG is rendered to a temp file and discarded.
+
+## Workflow (short)
+
+1. **If the diagram will live in Markdown**: draft it in a standalone `diagram.mmd` first (the tool only validates plain Mermaid files).
+2. Write/update `diagram.mmd`.
+3. Run `./tools/validate.sh diagram.mmd`.
+4. Fix any errors shown by the CLI.
+5. Once it validates, copy the Mermaid block into your Markdown file.

--- a/agents/skills/mermaid/tools/validate.sh
+++ b/agents/skills/mermaid/tools/validate.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Validate a Mermaid diagram by parsing + rendering to a temp SVG.
+# Usage: validate.sh diagram.mmd [output.svg]
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 diagram.mmd [output.svg]"
+    exit 1
+fi
+
+INPUT="$1"
+OUTPUT="${2:-}"
+
+if [ ! -f "$INPUT" ]; then
+    echo "Error: File not found: $INPUT"
+    exit 1
+fi
+
+CLEANUP=0
+if [ -z "$OUTPUT" ]; then
+    OUTPUT=$(mktemp /tmp/mermaid_validate.XXXXXX.svg)
+    CLEANUP=1
+fi
+
+trap 'if [ "$CLEANUP" -eq 1 ]; then rm -f "$OUTPUT"; fi' EXIT
+
+echo "Validating: $INPUT"
+
+# Use mermaid-cli (mmdc) to parse and render. Errors mean invalid syntax.
+if npx -y @mermaid-js/mermaid-cli -i "$INPUT" -o "$OUTPUT" -q; then
+    echo "✓ Mermaid OK"
+    echo ""
+    echo "ASCII preview:"
+    if ! MERMAID_INPUT="$INPUT" npx -y --package beautiful-mermaid node -e '
+const fs = require("node:fs");
+const path = require("node:path");
+const binPath = process.env.PATH.split(":")[0];
+const moduleRoot = path.dirname(binPath);
+const { renderMermaidAscii } = require(path.join(moduleRoot, "beautiful-mermaid"));
+const text = fs.readFileSync(process.env.MERMAID_INPUT, "utf8");
+process.stdout.write(renderMermaidAscii(text));
+process.stdout.write("\n");
+'; then
+        echo "Warning: ASCII preview failed (diagram type may be unsupported)."
+    fi
+    if [ "$CLEANUP" -eq 0 ]; then
+        echo "Rendered to: $OUTPUT"
+    fi
+else
+    echo "✗ Mermaid validation failed"
+    exit 1
+fi

--- a/agents/skills/playwright-cli/SKILL.md
+++ b/agents/skills/playwright-cli/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: playwright-cli
+description: Automate browser interactions, test web pages and work with Playwright tests.
+allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+# --submit presses Enter after filling the element
+playwright-cli fill e5 "user@example.com"  --submit
+playwright-cli drag e2 e8
+# drop files or data onto an element (from outside the page)
+playwright-cli drop e4 --path=./image.png
+playwright-cli drop e4 --data="text/plain=hello world"
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+# get element id, class, or any attribute not visible in the snapshot
+playwright-cli eval "el => el.id" e5
+playwright-cli eval "el => el.getAttribute('data-testid')" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli requests
+playwright-cli request 5
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli run-code --filename=script.js
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start video.webm
+playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
+playwright-cli video-stop
+
+# launch the dashboard for UI review / design feedback — user annotates the page, you receive the annotated screenshot, snapshot, and notes
+playwright-cli show --annotate
+
+# generate a Playwright locator for an element from its ref or selector
+playwright-cli generate-locator e5 --raw
+
+# show a persistent highlight overlay for an element, optionally with a custom style
+playwright-cli highlight e5
+playwright-cli highlight e5 --style="outline: 3px dashed red"
+# hide a single element highlight, or all page highlights when no target is given
+playwright-cli highlight e5 --hide
+playwright-cli highlight --hide
+```
+
+## Raw output
+
+The global `--raw` option strips page status, generated code, and snapshot sections from the output, returning only the result value. Use it to pipe command output into other tools. Commands that don't produce output return nothing.
+
+```bash
+playwright-cli --raw eval "JSON.stringify(performance.timing)" | jq '.loadEventEnd - .navigationStart'
+playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" > links.json
+playwright-cli --raw snapshot > before.yml
+playwright-cli click e5
+playwright-cli --raw snapshot > after.yml
+diff before.yml after.yml
+TOKEN=$(playwright-cli --raw cookie-get session_id)
+playwright-cli --raw localstorage-get theme
+```
+
+For structured output wrapping every reply as JSON, pass --json
+```bash
+playwright-cli list --json
+```
+
+## Open parameters
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Connect to browser via Playwright Extension
+playwright-cli attach --extension=chrome
+
+# Connect to a running Chrome or Edge by channel name
+playwright-cli attach --cdp=chrome
+playwright-cli attach --cdp=msedge
+
+# Connect to a running browser via CDP endpoint
+playwright-cli attach --cdp=http://localhost:9222
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Detach from an attached browser (leaves the external browser running)
+playwright-cli -s=msedge detach
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command. All the options below can be combined as needed.
+
+```bash
+# default - save to a file with timestamp-based name
+playwright-cli snapshot
+
+# save to file, use when snapshot is a part of the workflow result
+playwright-cli snapshot --filename=after-click.yaml
+
+# snapshot an element instead of the whole page
+playwright-cli snapshot "#main"
+
+# limit snapshot depth for efficiency, take a partial snapshot afterwards
+playwright-cli snapshot --depth=4
+playwright-cli snapshot e34
+
+# include each element's bounding box as [box=x,y,width,height]
+playwright-cli snapshot --boxes
+```
+
+## Targeting elements
+
+By default, use refs from the snapshot to interact with page elements.
+
+```bash
+# get snapshot with refs
+playwright-cli snapshot
+
+# interact using a ref
+playwright-cli click e15
+```
+
+You can also use css selectors or Playwright locators.
+
+```bash
+# css selector
+playwright-cli click "#main > button.submit"
+
+# role locator
+playwright-cli click "getByRole('button', { name: 'Submit' })"
+
+# test id
+playwright-cli click "getByTestId('submit-button')"
+```
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Installation
+
+If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+
+```bash
+npx --no-install playwright-cli --version
+```
+
+When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+
+```bash
+npm install -g @playwright/cli@latest
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli requests
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Example: Interactive session
+
+Ask the user for UI review or design feedback. The user draws boxes on the live page and types comments; you receive the annotated screenshot, the snapshot of the marked region, and the user's notes. Use this whenever the user asks for "UI review", "design feedback", or to "ask the user what they think / want / mean":
+
+```bash
+playwright-cli open https://example.com
+playwright-cli show --annotate
+```
+
+## Specific tasks
+
+* **Running and Debugging Playwright tests** [references/playwright-tests.md](references/playwright-tests.md)
+* **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+* **Running Playwright code** [references/running-code.md](references/running-code.md)
+* **Browser session management** [references/session-management.md](references/session-management.md)
+* **Spec-driven testing (plan / generate / heal)** [references/spec-driven-testing.md](references/spec-driven-testing.md)
+* **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+* **Test generation** [references/test-generation.md](references/test-generation.md)
+* **Tracing** [references/tracing.md](references/tracing.md)
+* **Video recording** [references/video-recording.md](references/video-recording.md)
+* **Inspecting element attributes** [references/element-attributes.md](references/element-attributes.md)

--- a/agents/skills/playwright-cli/references/element-attributes.md
+++ b/agents/skills/playwright-cli/references/element-attributes.md
@@ -1,0 +1,23 @@
+# Inspecting Element Attributes
+
+When the snapshot doesn't show an element's `id`, `class`, `data-*` attributes, or other DOM properties, use `eval` to inspect them.
+
+## Examples
+
+```bash
+playwright-cli snapshot
+# snapshot shows a button as e7 but doesn't reveal its id or data attributes
+
+# get the element's id
+playwright-cli eval "el => el.id" e7
+
+# get all CSS classes
+playwright-cli eval "el => el.className" e7
+
+# get a specific attribute
+playwright-cli eval "el => el.getAttribute('data-testid')" e7
+playwright-cli eval "el => el.getAttribute('aria-label')" e7
+
+# get a computed style property
+playwright-cli eval "el => getComputedStyle(el).display" e7
+```

--- a/agents/skills/playwright-cli/references/playwright-tests.md
+++ b/agents/skills/playwright-cli/references/playwright-tests.md
@@ -1,0 +1,39 @@
+# Running Playwright Tests
+
+To run Playwright tests, use the `npx playwright test` command, or a package manager script. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
+
+```bash
+# Run all tests
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+
+# Run all tests through a custom npm script
+PLAYWRIGHT_HTML_OPEN=never npm run special-test-command
+```
+
+# Debugging Playwright Tests
+
+To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions.
+
+**IMPORTANT**: run the command in the background and check the output until "Debugging Instructions" is printed. Make sure to stop the command after you have finished.
+
+Once instructions containing a session name are printed, use `playwright-cli` to attach the session and explore the page.
+
+```bash
+# Run the test
+PLAYWRIGHT_HTML_OPEN=never npx playwright test --debug=cli
+# ...
+# ... debugging instructions for "tw-abcdef" session ...
+# ...
+
+# Attach to the test
+playwright-cli attach tw-abcdef
+```
+
+Keep the test running in the background while you explore and look for a fix.
+The test is paused at the start, so you should step over or pause at a particular location
+where the problem is most likely to be.
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into the test. Most of the time, a specific locator or an expectation should be updated, but it could also be a bug in the app. Use your judgement.
+
+After fixing the test, stop the background test run. Rerun to check that test passes.

--- a/agents/skills/playwright-cli/references/request-mocking.md
+++ b/agents/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/agents/skills/playwright-cli/references/running-code.md
+++ b/agents/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,241 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+You can also load the function from a file:
+
+```bash
+playwright-cli run-code --filename=./my-script.js
+```
+
+
+The code must be a single function expression, it is wrapped in `(...)` and evaluated.
+import/export/require syntax is not supported.
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.locator('.loading').waitFor({ state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.locator('.result').waitFor({ timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('secret');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/agents/skills/playwright-cli/references/session-management.md
+++ b/agents/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,225 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Attaching to a Running Browser
+
+Use `attach` to connect to a browser that is already running, instead of launching a new one.
+
+### Attach by channel name
+
+Connect to a running Chrome or Edge instance by its channel name. The browser must have remote debugging enabled — navigate to `chrome://inspect/#remote-debugging` in the target browser and check "Allow remote debugging for this browser instance".
+
+```bash
+# Attach to Chrome
+playwright-cli attach --cdp=chrome
+
+# Attach to Chrome Canary
+playwright-cli attach --cdp=chrome-canary
+
+# Attach to Microsoft Edge
+playwright-cli attach --cdp=msedge
+
+# Attach to Edge Dev
+playwright-cli attach --cdp=msedge-dev
+```
+
+Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
+
+When `--session` is not provided, the session is named after the channel (e.g. `--cdp=msedge` creates a session called `msedge`), so parallel attaches to Chrome and Edge don't collide on `default`. Pass `--session=<name>` to override.
+
+### Attach via CDP endpoint
+
+Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
+
+```bash
+playwright-cli attach --cdp=http://localhost:9222
+```
+
+### Attach via browser extension
+
+Connect to a browser with the Playwright extension installed:
+
+```bash
+playwright-cli attach --extension
+```
+
+### Detach
+
+Tear down an attached session without affecting the external browser:
+
+```bash
+# Detach the default attached session
+playwright-cli detach
+
+# Detach a specific attached session
+playwright-cli -s=msedge detach
+```
+
+`detach` only works on sessions created via `attach`. For sessions created via `open`, use `close`.
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/agents/skills/playwright-cli/references/spec-driven-testing.md
+++ b/agents/skills/playwright-cli/references/spec-driven-testing.md
@@ -1,0 +1,305 @@
+# Spec-driven testing (plan → generate → heal)
+
+End-to-end workflow for authoring and maintaining Playwright tests using `playwright-cli`. The three sections below can be used independently:
+
+- **Planning** — explore the app, produce a spec file describing what to test.
+- **Generate** — turn a spec into Playwright test files. Update the spec if it's vague or stale.
+- **Heal** — diagnose failing tests, fix the code, reconcile the spec with reality.
+
+All three lean on the same mechanic: run `npx playwright test --debug=cli` in the background, then `playwright-cli attach tw-XXXX` to drive the paused page interactively. See [playwright-tests.md](playwright-tests.md) for the debug/attach mechanics and [test-generation.md](test-generation.md) for how every `playwright-cli` action emits Playwright TypeScript.
+
+---
+
+## 1. Planning
+
+Goal: produce a spec file (e.g. `specs/<feature>.plan.md`) that enumerates the scenarios to test. **Always** write the spec to a file.
+
+### 1.1 Prerequisite: workspace
+
+Check the workspace has Playwright installed before anything else:
+
+```bash
+# Either of these confirms a workspace:
+test -f playwright.config.ts || test -f playwright.config.js
+npx --no-install playwright --version
+```
+
+If there is no Playwright install, bootstrap one and let the user pick the defaults:
+
+```bash
+npm init playwright@latest
+```
+
+### 1.2 Prerequisite: seed test
+
+A **seed test** is a minimal test that lands the page in the state every scenario starts from: navigation to the app, any required login, feature flags, etc. Scenarios assume a fresh start *after* the seed. `--debug=cli` pauses *inside* this test, so the seed is where every planning and generation session begins.
+
+Minimum viable seed:
+
+```ts
+// tests/seed.spec.ts
+import { test } from '@playwright/test';
+
+test('seed', async ({ page }) => {
+  await page.goto('https://example.com/');
+});
+```
+
+Preferred — push navigation into a fixture so scenario tests reuse it:
+
+```ts
+// tests/fixtures.ts
+import { test as baseTest } from '@playwright/test';
+export { expect } from '@playwright/test';
+
+export const test = baseTest.extend({
+  page: async ({ page }, use) => {
+    await page.goto('https://example.com/');
+    await use(page);
+  },
+});
+```
+
+```ts
+// tests/seed.spec.ts
+import { test } from './fixtures';
+
+test('seed', async ({ page }) => {
+  // Fixture already navigates. This empty body tells agents where to start.
+});
+```
+
+If no seed exists, create one that at least navigates to the app.
+
+### 1.3 Explore the app
+
+Launch the app via the seed in the background and attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/seed.spec.ts --debug=cli
+# wait for "Debugging Instructions" and the session name tw-XXXX
+playwright-cli attach tw-XXXX
+```
+
+Resume so the seed runs, then probe the app:
+
+```bash
+playwright-cli resume                   # resume so that seed test runs fully
+playwright-cli snapshot                 # inventory of interactive elements
+playwright-cli click e5                 # follow a flow
+playwright-cli eval "location.href"     # read URL / state
+playwright-cli show --annotate          # ask the user to point at something
+```
+
+Map out:
+
+- Interactive surfaces (forms, buttons, lists, filters, modals).
+- Primary user journeys end-to-end.
+- Edge cases: empty states, validation errors, very long input, boundary values.
+- Persistence: reload, local/session storage, URL fragments.
+- Navigation: which controls change the URL, back/forward behaviour.
+
+**Important**: Do not just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+**Important**: Stop the background test when done exploring.
+
+### 1.4 Write the spec file
+
+Save under `specs/<feature>.plan.md`. Use this structure:
+
+```markdown
+# <Feature> Test Plan
+
+## Application Overview
+
+<One paragraph describing what the feature does and why it matters.>
+
+## Test Scenarios
+
+### 1. <Group Name>
+
+**Seed:** `tests/seed.spec.ts`
+
+#### 1.1. <kebab-case-scenario-name>
+
+**File:** `tests/<group>/<kebab-case-scenario-name>.spec.ts`
+
+**Steps:**
+  1. <Concrete user step>
+    - expect: <observable outcome>
+    - expect: <another observable outcome>
+  2. <Next step>
+    - expect: <outcome>
+
+#### 1.2. <next-scenario>
+...
+
+### 2. <Next Group>
+
+**Seed:** `tests/seed.spec.ts`
+...
+```
+
+Guidelines:
+
+- Each scenario is independent and starts from the seed's fresh state — never chain scenarios.
+- Scenario names are kebab-case and match the test file name (`should-add-single-todo` → `should-add-single-todo.spec.ts`).
+- Cover happy path, edge cases, validation, negative flows, persistence.
+- Write steps at the user level ("Type 'Buy milk' into the input"), not the API level ("call `fill`").
+- Put observable outcomes in `- expect:` bullets; each becomes an assertion during generation.
+
+---
+
+## 2. Generate
+
+Goal: take a spec file and produce Playwright test files. Optionally update the spec if it has drifted.
+
+### 2.1 Inputs
+
+- **Spec file**, e.g. `specs/basic-operations.plan.md`.
+- **Target**: either a single scenario (e.g. `1.2`), a whole group (`1`), or all.
+- **Seed file**, read from the `**Seed:**` line of the scenario's group.
+
+### 2.2 Generate one scenario
+
+For each target scenario, in sequence (never in parallel — scenarios share the seed session):
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test <seed-file> --debug=cli   # background
+playwright-cli attach tw-XXXX
+# resume
+```
+
+**Do not** just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+
+Walk the scenario's `Steps:` one by one with `playwright-cli`, treating the spec as the plan and the live app as the source of truth. If a step is vague ("click the button" — which button?), references an element that no longer exists, or contradicts the app's actual behaviour, use your judgement: update the spec to match what the app really does, then keep going. Editing the spec mid-generation is expected.
+
+Every action prints the equivalent Playwright TypeScript (see [test-generation.md](test-generation.md)):
+
+```bash
+playwright-cli snapshot                         # find refs
+playwright-cli fill e3 "John Doe"               # -> page.getByRole('textbox', {...}).fill(...)
+playwright-cli press Enter
+playwright-cli click e7
+```
+
+For each `- expect:` bullet, add an explicit assertion. See [test-generation.md](test-generation.md) for details.
+
+Collect the generated code and write the test file at the path given in the spec:
+
+```ts
+// spec: specs/basic-operations.plan.md
+// seed: tests/seed.spec.ts
+import { test, expect } from './fixtures';   // or '@playwright/test' if no fixtures file
+
+test.describe('Singing in and out', () => {
+  test('should sign in', async ({ page }) => {
+    // 1. Navigate to the application
+    // (handled by the seed fixture)
+
+    // 2. Type 'John Doe' into the username field
+    await page.getByRole('textbox', { name: 'username' }).fill('John Doe');
+
+    // 3. Type password
+    await page.getByRole('textbox', { name: 'password' }).fill('TestPassword');
+
+    // 4. Press Enter to submit
+    await page.getByRole('textbox', { name: 'password' }).press('Enter');
+
+    await expect(page.getByRole('heading')).toContainText('Welcome, John Doe!');
+  });
+});
+```
+
+Rules:
+
+- **One test per file.** File path, describe name, and test name come verbatim from the spec (minus the ordinal).
+- Prefix each numbered step with a `// N. <step text>` comment before its actions.
+- Use the describe group name verbatim from the spec (no `1.` ordinal).
+- Import from `./fixtures` if the project has one; otherwise `@playwright/test`.
+- **Important**: close the CLI session and stop the background test before moving to the next scenario.
+
+### 2.3 Generate multiple scenarios
+
+Loop 2.2 over the targeted scenarios one at a time, restarting the seed between each so every test starts from a clean page. This is safe to parallelise due to unique generated session names - just make sure each test run is stopped.
+
+### 2.4 Run generated tests
+
+After generation, run the new tests once:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts
+```
+
+Any failure goes to Section 3.
+
+---
+
+## 3. Heal
+
+Goal: fix failing tests, and update the spec if the app's intended behaviour changed.
+
+### 3.1 Find failing tests
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+```
+
+Record the list of failing `<file>:<line>` entries and process them one at a time. Do not attempt parallel fixes — shared state and the single CLI session make that fragile.
+
+### 3.2 Debug one failure
+
+Run the single failing test in debug mode in the background, then attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts:<line> --debug=cli
+# wait for "Debugging Instructions" and the tw-XXXX session name
+playwright-cli attach tw-XXXX
+```
+
+The test is paused at the start. Step forward or run to until just before the failing action or assertion, then diagnose:
+
+```bash
+playwright-cli snapshot                # did the element change / move / rename?
+playwright-cli console                 # app-side errors?
+playwright-cli network                 # failed request? wrong payload?
+playwright-cli show --annotate         # ask the user to point somewhere
+```
+
+Common causes: selector drift, new wrapper element, label/ARIA rename, timing (transition, async load), assertion text updated in the app, test data leaking between runs.
+
+Rehearse the corrected interaction with `playwright-cli` — the generated code in the output is what you paste back into the test.
+
+### 3.3 Apply the fix
+
+Edit the test file: update the locator, assertion, step order, or inputs to match the corrected behaviour. Stop the background debug run. Rerun the single test to confirm green.
+
+Never skip hooks or add sleeps as a fix. Never use `networkidle`.
+
+### 3.4 Reconcile with the spec
+
+Open the spec referenced by the `// spec:` header in the test file and locate the scenario that matches the test.
+
+- **Fix was purely technical** (locator drift, better assertion shape) and the spec's user-level behaviour still matches the app → leave the spec alone.
+- **Fix changed user-visible steps, inputs, order, or expected outcomes** that the spec describes → update the spec to match reality. Keep the scenario id and file path stable; only the step / expect lines change.
+- **Unclear whether the app change is intentional** (spec is stale) **or a regression** (test was right, app is wrong) → **stop and ask the user**. Provide:
+  - the scenario id (e.g. `2.3`),
+  - the spec lines that no longer match,
+  - the observed app behaviour (quote a snapshot excerpt or a concrete outcome).
+
+Only after the user answers, either update the spec (intentional change) or file/flag the test as covering a bug (regression).
+
+### 3.5 Iteration and giving up
+
+- Fix failures one at a time; rerun after each.
+- If after thorough investigation you are confident the test is correct but the app is wrong *and* the user has confirmed it's a bug: mark the test `test.fixme(...)` with a comment pointing at the user's decision or issue link. Never silently skip.
+
+---
+
+## Cross-references
+
+| For... | See |
+|---|---|
+| `--debug=cli` / attach mechanics | [playwright-tests.md](playwright-tests.md) |
+| How `playwright-cli` actions become TS | [test-generation.md](test-generation.md) |
+| Mocking requests during exploration/generation | [request-mocking.md](request-mocking.md) |
+| Managing the CLI browser session | [session-management.md](session-management.md) |

--- a/agents/skills/playwright-cli/references/storage-state.md
+++ b/agents/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/agents/skills/playwright-cli/references/test-generation.md
+++ b/agents/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,134 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your test using one of the recommended matchers:
+
+- `toBeVisible()` — element is rendered and visible
+- `toHaveText(text)` — element text content matches
+- `toHaveValue(value) / toBeEmpty()` — input/select value matches
+- `toBeChecked() / toBeUnchecked()` — checkbox state matches
+- `toMatchAriaSnapshot(snapshot)` — page (or locator) matches a partial accessibility snapshot
+
+Use `playwright-cli generate-locator <target>` to produce the locator expression for the assertion, and the snapshot/eval commands to capture the expected value.
+
+When asserting text content, make sure that generated locator does not contain text from the element itself. `getByTestId()` or `getByLabel()` usually work well with asserting text. When locator is text-based, prefer `toBeVisible()` instead.
+
+Snapshot to be matched does not have to contain all the information - only capture what's necessary for the assertion. You can use regular expressions for unstable values.
+
+```bash
+# Get a stable locator for an element ref to use in the assertion
+playwright-cli --raw generate-locator e5
+# getByRole('button', { name: 'Submit' })
+
+# Capture expected text content for toHaveText
+playwright-cli --raw eval "el => el.textContent" e5
+
+# Capture expected input value for toHaveValue/toBeEmpty
+playwright-cli --raw eval "el => el.value" e5
+
+# Capture expected aria snapshot for toMatchAriaSnapshot/toBeChecked
+# (whole page, or use a ref to scope to a region)
+playwright-cli --raw snapshot
+playwright-cli --raw snapshot e5
+```
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertions using the outputs above:
+await expect(page.getByRole('alert', { name: 'Success' })).toBeVisible();
+await expect(page.getByTestId('main-header')).toHaveText('Welcome, user');
+await expect(page.getByRole('textbox', { name: 'Email' })).toHaveValue('user@example.com');
+await expect(page.getByRole('checkbox', { name: 'Enable notifications' })).toBeChecked();
+
+// toMatchAriaSnapshot on the whole page, finds a matching region
+await expect(page).toMatchAriaSnapshot(`
+  - heading "Welcome, user"
+  - link /\\d+ new messages?/
+  - button "Sign out"
+`);
+
+// toMatchAriaSnapshot scoped to a region
+await expect(page.getByRole('navigation')).toMatchAriaSnapshot(`
+  - link "Home"
+  - link /\\d+ new messages?/
+  - link "Profile"
+`);
+```

--- a/agents/skills/playwright-cli/references/tracing.md
+++ b/agents/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,139 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM** | Full DOM snapshot before/after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All requests, responses, headers, bodies, timing |
+| **Console** | All console.log, warn, error messages |
+| **Timing** | Precise timing for each operation |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos | Quick capture |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/agents/skills/playwright-cli/references/video-recording.md
+++ b/agents/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,143 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Open browser first
+playwright-cli open
+
+# Start recording
+playwright-cli video-start demo.webm
+
+# Add a chapter marker for section transitions
+playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
+
+# Navigate and perform actions
+playwright-cli goto https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+
+# Add another chapter
+playwright-cli video-chapter "Filling Form" --description="Entering test data" --duration=2000
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-start recordings/login-flow-2024-01-15.webm
+playwright-cli video-start recordings/checkout-test-run-42.webm
+```
+
+### 2. Record entire hero scripts.
+
+When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
+It allows pulling appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+
+1) Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request their bounding boxes for highlight.
+2) Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.
+3) Use playwright-cli run-code --filename your-script.js
+
+**Important**: Overlays are `pointer-events: none` — they do not interfere with page interactions. You can safely keep sticky overlays visible while clicking, filling, or performing any actions on the page.
+
+```js
+async page => {
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  await page.goto('https://demo.playwright.dev/todomvc');
+
+  // Show a chapter card — blurs the page and shows a dialog.
+  // Blocks until duration expires, then auto-removes.
+  // Use this for simple use cases, but always feel free to hand-craft your own beautiful
+  // overlay via await page.screencast.showOverlay().
+  await page.screencast.showChapter('Adding Todo Items', {
+    description: 'We will add several items to the todo list.',
+    duration: 2000,
+  });
+
+  // Perform action
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Walk the dog', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1000);
+
+  // Show next chapter
+  await page.screencast.showChapter('Verifying Results', {
+    description: 'Checking the item appeared in the list.',
+    duration: 2000,
+  });
+
+  // Add a sticky annotation that stays while you perform actions.
+  // Overlays are pointer-events: none, so they won't block clicks.
+  const annotation = await page.screencast.showOverlay(`
+    <div style="position: absolute; top: 8px; right: 8px;
+      padding: 6px 12px; background: rgba(0,0,0,0.7);
+      border-radius: 8px; font-size: 13px; color: white;">
+      ✓ Item added successfully
+    </div>
+  `);
+
+  // Perform more actions while the annotation is visible
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Buy groceries', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1500);
+
+  // Remove the annotation when done
+  await annotation.dispose();
+
+  // You can also highlight relevant locators and provide contextual annotations.
+  const bounds = await page.getByText('Walk the dog').boundingBox();
+  await page.screencast.showOverlay(`
+    <div style="position: absolute;
+      top: ${bounds.y}px;
+      left: ${bounds.x}px;
+      width: ${bounds.width}px;
+      height: ${bounds.height}px;
+      border: 1px solid red;">
+    </div>
+    <div style="position: absolute;
+      top: ${bounds.y + bounds.height + 5}px;
+      left: ${bounds.x + bounds.width / 2}px;
+      transform: translateX(-50%);
+      padding: 6px;
+      background: #808080;
+      border-radius: 10px;
+      font-size: 14px;
+      color: white;">Check it out, it is right above this text
+    </div>
+  `, { duration: 2000 });
+
+  await page.screencast.stop();
+}
+```
+
+Embrace creativity, overlays are powerful.
+
+### Overlay API Summary
+
+| Method | Use Case |
+|--------|----------|
+| `page.screencast.showChapter(title, { description?, duration?, styleSheet? })` | Full-screen chapter card with blurred backdrop — ideal for section transitions |
+| `page.screencast.showOverlay(html, { duration? })` | Custom HTML overlay — use for callouts, labels, highlights |
+| `disposable.dispose()` | Remove a sticky overlay added without duration |
+| `page.screencast.hideOverlays()` / `page.screencast.showOverlays()` | Temporarily hide/show all overlays |
+
+## Tracing vs Video
+
+| Feature | Video | Tracing |
+|---------|-------|---------|
+| Output | WebM file | Trace file (viewable in Trace Viewer) |
+| Shows | Visual recording | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis |
+| Size | Larger | Smaller |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/agents/skills/rebasing-prs/SKILL.md
+++ b/agents/skills/rebasing-prs/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: rebasing-prs
+description: Rebases the current PR branch onto its base (usually `origin/main`), resolves conflicts with intent-aware decisions, and offers a safe force-push afterwards. Use when the user says "rebase", "rebase on main", "update branch with latest", "sync with main", "fix rebase conflicts", or when a PR is behind its base. Never rebase `main`/`master` itself; never plain `--force`-push.
+---
+
+# Rebasing PRs
+
+**Announce:** "I'm using the rebasing-prs skill."
+
+## Step 1: Pre-flight Checks
+
+Refuse to proceed unless all of these hold:
+
+```bash
+# Current branch — must NOT be main/master/develop
+git rev-parse --abbrev-ref HEAD
+
+# Working tree must be clean (no uncommitted changes, no untracked files
+# that would be clobbered). If dirty, ask the user whether to stash or stop.
+git status --porcelain
+
+# Confirm there is an upstream / a base to rebase onto
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "no upstream"
+```
+
+If on `main`/`master`/`develop`, **stop** and tell the user. Do not rebase the trunk.
+
+If the working tree is dirty, ask: stash and continue, or abort?
+
+## Step 2: Identify the Base Branch
+
+The base is the branch the PR will merge into — usually `main`, but check:
+
+```bash
+# If there's an open PR, ask GitHub for its base
+gh pr view --json baseRefName -q .baseRefName 2>/dev/null
+
+# Otherwise default to the repo's default branch
+gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null \
+  || echo "main"
+```
+
+Record the result as `BASE` (e.g. `main`). The remote ref to rebase onto is `origin/$BASE`.
+
+## Step 3: Fetch and Understand What Changed
+
+```bash
+git fetch origin
+
+# Commits on the base since this branch diverged — read these to understand
+# the *intent* of upstream changes before resolving conflicts.
+git log --oneline HEAD..origin/$BASE
+
+# For files that are likely to conflict, look at *why* they changed upstream:
+git log -p HEAD..origin/$BASE -- <path>
+```
+
+This is the key insight from how others do this well: resolving conflicts blind produces bad merges. Read upstream commit messages and diffs first so you can preserve the intent of both sides.
+
+## Step 4: Rebase
+
+```bash
+git rebase origin/$BASE
+```
+
+If it completes cleanly, skip to Step 6.
+
+## Step 5: Resolve Conflicts
+
+For each conflicted file, decide which bucket it falls into:
+
+| File type | Strategy |
+|---|---|
+| **Lock files** (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Gemfile.lock`, `poetry.lock`, `uv.lock`, `Cargo.lock`) | Accept theirs (`git checkout --theirs <file>`), then regenerate from the resolved manifest (`npm install`, `pnpm install`, `bundle install`, `poetry lock`, `cargo build`, etc.). |
+| **DB migrations** (sequential numbering matters) | **Stop and ask the user.** Reordering migrations can break the database. |
+| **Generated files** (snapshots, build artifacts) | Regenerate after resolving the source. |
+| **Code** | Read both sides + the relevant upstream commit to understand intent. Preserve both changes when they're orthogonal. Pick one side only when they truly conflict on the same concern. |
+
+After resolving each file:
+
+```bash
+git add <file>
+git rebase --continue
+```
+
+If you get stuck or it's clear the resolution is non-trivial, stop and surface the conflict to the user with context (which file, what upstream did, what this branch did, your proposed resolution).
+
+At any point, `git rebase --abort` returns to the pre-rebase state safely.
+
+## Step 6: Verify
+
+```bash
+# Sanity check — branch should now be ahead of, not behind, base
+git log --oneline origin/$BASE..HEAD
+git log --oneline HEAD..origin/$BASE   # should be empty
+
+# Run the project's tests / typecheck / lint as appropriate
+```
+
+If tests fail, the rebase semantically broke something even if it merged textually. Investigate before pushing.
+
+## Step 7: Offer to Push (only if conflicts were trivial)
+
+Classify the rebase as **trivial** if all of these hold:
+- No conflicts, OR conflicts were only lock-file regenerations / pure-formatting / clearly-orthogonal hunks
+- Tests still pass
+- No migration / schema / generated-code conflicts
+- You did not have to make a judgment call between two competing implementations
+
+If trivial, ask the user:
+
+> Rebase looks clean (or: only conflicts were `<lock-file>`, regenerated). Want me to push with `--force-with-lease`?
+
+If they say yes:
+
+```bash
+git push --force-with-lease --force-if-includes
+```
+
+If **non-trivial** (real code conflicts, judgment calls, test changes, migrations): **do not offer to push.** Summarize what you did and let the user review the rebased branch first. They push when they're satisfied.
+
+## Hard Rules
+
+- Never `git push --force` (without `--with-lease`). Always `--force-with-lease`, ideally with `--force-if-includes`.
+- Never rebase `main`/`master`/`develop`/release branches.
+- Never `git rebase --skip` to make conflicts go away — that silently drops commits.
+- Never run `git reset --hard` to "fix" a bad rebase mid-flight; use `git rebase --abort`.
+- If the branch is shared with other contributors, warn the user before force-pushing — rebasing rewrites history they may have pulled.
+
+## Checklist
+
+- [ ] Not on `main`/`master`
+- [ ] Working tree clean (or stashed with user's OK)
+- [ ] Base branch identified, `origin/$BASE` fetched
+- [ ] Read upstream commits before resolving conflicts
+- [ ] Conflicts resolved with intent preserved; lock files regenerated
+- [ ] Tests pass after rebase
+- [ ] Trivial → asked user about `--force-with-lease` push; non-trivial → handed back for review

--- a/agents/skills/receiving-code-review/SKILL.md
+++ b/agents/skills/receiving-code-review/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: receiving-code-review
+description: Guides how to process and respond to code review feedback — categorizing comments, making changes systematically, and responding to reviewers. Use when a pull request or code has received review comments, or when the user says "I got feedback on my PR", "reviewer left comments", "how do I respond to this review", or "addressing review feedback". Never dismiss feedback without engaging with it; never make changes without understanding why.
+---
+
+# Receiving Code Review
+
+**Announce:** "I'm using the receiving-code-review skill."
+
+## Mindset
+
+Code review is collaborative, not adversarial. The reviewer wants the code to be good. Even if a comment feels wrong, engage with the underlying concern before disagreeing.
+
+## Step 1: Read Everything Before Responding
+
+Read all comments before making any changes. You need the full picture to understand if comments are related, if there's a theme, or if early changes affect later ones.
+
+## Step 2: Categorize Each Comment
+
+| Category | Meaning | Action |
+|---|---|---|
+| **Must fix** | Correctness, security, data loss | Fix it, no debate |
+| **Should fix** | Maintainability, convention, clarity | Fix it unless you have a strong reason |
+| **Suggestion** | Style, preference, "consider..." | Discuss, then decide |
+| **Question** | Reviewer wants to understand | Answer it in the PR or in code comments |
+| **Praise** | 👍, "nice" | Acknowledge, move on |
+
+## Step 3: Work Through Fixes Systematically
+
+For each must-fix and should-fix:
+
+1. Understand **why** the reviewer flagged it before writing the fix
+2. Make the change
+3. Run tests — don't assume a "small change" is safe
+4. Commit changes (one logical commit per distinct concern, or squash at the end)
+
+## Step 4: Respond to Each Comment
+
+On every comment, leave a response:
+- **Fixed:** "Done — changed X to Y"
+- **Agreed with discussion:** "Good point, I've updated this. The key thing I missed was..."
+- **Disagree (respectfully):** "I see the concern about X. My thinking was [reason]. Would [alternative] address it?"
+- **Question answered:** Answer it in the reply; if the code was unclear, fix the code too
+
+**Never:**
+- Resolve a comment without explaining what you did
+- Reply "fixed" without actually fixing it
+- Ignore a comment silently
+
+## Step 5: Re-Request Review
+
+Once all comments are addressed:
+
+```
+Addressed all feedback. Summary of changes:
+- [comment 1]: [what you did]
+- [comment 2]: [what you did]
+- [comment 3]: Left as-is because [reason] — let me know if you'd like to discuss
+
+Ready for another look.
+```
+
+## Checklist
+
+- [ ] All comments read before making changes
+- [ ] Every must-fix and should-fix addressed
+- [ ] Tests still passing after changes
+- [ ] Every comment responded to (even if just "acknowledged")
+- [ ] Review re-requested with summary

--- a/agents/skills/ripgrep/SKILL.md
+++ b/agents/skills/ripgrep/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: ripgrep
+description: "Search for content in the codebase using the `rg` (ripgrep) tool."
+---
+
+# ripgrep Skill
+
+Use `ripgrep` (`rg`) to search for text or patterns within files. It is highly optimized and respects `.gitignore` by default.
+
+## Basic Search
+
+Find a literal string:
+```bash
+rg -F "search_term"
+```
+
+Find a pattern using regular expressions:
+```bash
+rg "pattern_regex"
+```
+
+Search in a specific file or directory (defaults to current directory):
+```bash
+rg "query" path/to/file
+```
+
+## Filtering
+
+**By File Type:**
+Use `--type` (`-t`) to limit search to specific types (e.g., `rust`, `python`, `json`, `html`).
+```bash
+rg "search_term" -t rust
+```
+
+**By Glob Pattern:**
+Use `-g` to include/exclude files based on patterns:
+```bash
+# Only search in .js and .ts files
+rg "query" -g "*.{js,ts}"
+
+# Exclude a specific directory manually
+rg "query" --glob "!node_modules/*"
+```
+
+## Advanced Output
+
+**Only show matches:**
+Use `-o` to only output the matching part of the line.
+```bash
+rg -o "pattern"
+```
+
+**Replace text in output:**
+Use `--replace` (or `-r`) to replace the matched portion with a different string.
+```bash
+rg "old_term" --replace "new_term"
+# or
+rg "old_term" -r "new_term"
+```
+
+## Handling Binary and Hidden Files
+
+By default, `rg` hides binary files and hidden files. To include them:
+- Include hidden files: `-u` (or `--hidden`)
+- Include binary files: `-a` (or `--text`)
+- More intensive search (ignores all defaults): `-uu` or `-uuu`
+
+```bash
+# Search including hidden files
+rg --hidden "query"
+
+# Force search in everything even if it's a binary file
+rg -a "query"
+```

--- a/agents/skills/subagent-driven-development/SKILL.md
+++ b/agents/skills/subagent-driven-development/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: subagent-driven-development
+description: Implements a plan task-by-task using a two-stage review cycle — spec compliance first, then code quality. Use when an implementation plan is ready and the user wants to execute it with discipline. Triggers on "execute the plan", "implement this plan", "start working through the tasks", "let's build this", or when a writing-plans skill output is ready to be worked. Each task gets a fresh context and two-stage review before moving on.
+---
+
+# Subagent-Driven Development
+
+**Announce:** "I'm using the subagent-driven-development skill. I'll work through the plan task by task with review after each."
+
+## The Loop
+
+For each task in the plan:
+
+```
+1. IMPLEMENT — work the task as specified
+2. REVIEW STAGE 1 — spec compliance
+3. REVIEW STAGE 2 — code quality
+4. COMMIT — only after both reviews pass
+5. REPORT — summary to user before next task
+```
+
+Never start the next task until the current one passes both reviews.
+
+## Stage 1: Spec Compliance Review
+
+Check the implementation against the plan:
+
+- [ ] Does it implement exactly what the task specified?
+- [ ] Are all the required files created/modified?
+- [ ] Are the tests written and passing?
+- [ ] Does it match the interfaces defined in the plan?
+- [ ] No extra features or "while I'm here" additions?
+
+If anything fails: fix it before Stage 2.
+
+## Stage 2: Code Quality Review
+
+Check the code itself:
+
+- [ ] No magic numbers or unexplained constants
+- [ ] No dead code or commented-out blocks
+- [ ] Names are clear and consistent with the codebase
+- [ ] No obvious performance issues (N+1 queries, unnecessary loops)
+- [ ] Error cases handled appropriately
+- [ ] No debug output left in
+
+If anything fails: fix it before committing.
+
+## After Each Task
+
+Commit the work:
+```bash
+git add [changed files]
+git commit -m "[type]: [what was implemented]"
+```
+
+Report to the user:
+```
+✅ Task [N] complete: [task name]
+Files changed: [list]
+Tests: [X passing]
+
+Next: Task [N+1] — [task name]
+Proceed?
+```
+
+Wait for confirmation before the next task.
+
+## If a Task is Blocked
+
+If a task can't be completed as specified (missing dependency, spec is ambiguous, discovered a problem):
+
+1. **Stop** — don't improvise around it
+2. **Report** what's blocking and why
+3. **Propose** options: skip, modify spec, or address the blocker first
+4. **Wait** for user decision
+
+## Checklist Before Declaring Plan Complete
+
+- [ ] All tasks completed and committed
+- [ ] Full test suite passing
+- [ ] No tasks skipped without user sign-off
+- [ ] Ready to invoke finishing-a-development-branch

--- a/agents/skills/summarize/SKILL.md
+++ b/agents/skills/summarize/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: summarize
+description: "Fetch a URL or convert a local file (PDF/DOCX/HTML/etc.) into Markdown using `uvx markitdown`, optionally it can summarize"
+---
+
+Turn “things” (URLs, PDFs, Word docs, PowerPoints, HTML pages, text files, etc.) into **Markdown** so they can be inspected/quoted/processed like normal text.
+
+`markitdown` can fetch URLs by itself; this skill mainly wraps it to make saving + summarizing convenient.
+For PDF inputs, use the `markitdown[pdf]` extra (or the wrapper below, which now does this automatically).
+
+## When to use
+
+Use this skill when you need to:
+- pull down a web page as a document-like Markdown representation
+- convert binary docs (PDF/DOCX/PPTX) into Markdown for analysis
+- quickly produce a short summary of a long document before deeper work
+
+## Quick usage
+
+### Convert a URL or file to Markdown
+
+Run from **this skill folder** (the agent should `cd` here first):
+
+```bash
+uvx --from 'markitdown[pdf]' markitdown <url-or-path>
+```
+
+To write Markdown to a temp file (prints the path) use the wrapper:
+
+```bash
+node to-markdown.mjs <url-or-path> --tmp
+```
+
+Tip: when summarizing, the script will **always** write the full converted Markdown to a temp `.md` file and will **always** print a final "Hint" line with the path (so you can open/inspect the full content).
+
+Write Markdown to a specific file:
+
+```bash
+uvx --from 'markitdown[pdf]' markitdown <url-or-path> > /tmp/doc.md
+```
+
+### Convert + summarize with haiku-4-5 (pass context!)
+
+Summaries are only useful when you provide **what you want extracted** and the **audience/purpose**.
+
+```bash
+node to-markdown.mjs <url-or-path> --summary --prompt "Summarize focusing on X, for audience Y. Extract Z."
+```
+
+Or:
+
+```bash
+node to-markdown.mjs <url-or-path> --summary --prompt "Focus on security implications and action items."
+```
+
+This will:
+1) convert to Markdown via `uvx --from 'markitdown[pdf]' markitdown`
+2) write the full Markdown to a temp `.md` file and print its path as a "Hint" line
+3) run `pi --model claude-haiku-4-5` (no-tools, no-session) to summarize using your extra prompt

--- a/agents/skills/summarize/to-markdown.mjs
+++ b/agents/skills/summarize/to-markdown.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * Convert a URL or local file to Markdown using `uvx markitdown`.
+ * Optionally summarize the produced Markdown via `pi` (claude-haiku-4-5).
+ *
+ * Note: `markitdown` can fetch URLs on its own; this script mainly adds:
+ *   - optional writing to a temp file / specific output path
+ *   - optional summarization via `pi`
+ *   - ability to add a *custom summary prompt/context* (highly recommended)
+ *
+ * Usage:
+ *   node to-markdown.mjs <url-or-path> [--out <file>] [--tmp] [--summary [prompt]] [--prompt <prompt>]
+ *
+ * Examples:
+ *   node to-markdown.mjs https://example.com
+ *   node to-markdown.mjs ./spec.pdf --tmp
+ *   node to-markdown.mjs ./spec.pdf --summary "Summarize focusing on security and compliance requirements."
+ *   node to-markdown.mjs ./spec.pdf --summary --prompt "Extract API endpoints and auth details."
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { basename, join } from 'path';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+
+const argv = process.argv.slice(2);
+
+function usageAndExit(code = 1) {
+  console.error('Usage: node to-markdown.mjs <url-or-path> [--out <file>] [--tmp] [--summary [prompt]] [--prompt <prompt>]');
+  process.exit(code);
+}
+
+function isFlag(s) {
+  return typeof s === 'string' && s.startsWith('--');
+}
+
+function isUrl(s) {
+  return /^https?:\/\//i.test(s);
+}
+
+function ensureDir(path) {
+  mkdirSync(path, { recursive: true });
+}
+
+function safeName(s) {
+  return (s || 'document').replace(/[^a-z0-9._-]+/gi, '_');
+}
+
+function getInputBasename(s) {
+  if (isUrl(s)) {
+    const u = new URL(s);
+    const b = basename(u.pathname);
+    return safeName(b || 'document');
+  }
+  return safeName(basename(s));
+}
+
+function makeTmpMdPath(input) {
+  const dir = join(tmpdir(), 'pi-summarize-out');
+  ensureDir(dir);
+  const base = getInputBasename(input);
+  const stamp = Date.now().toString(36);
+  const rand = Math.random().toString(16).slice(2, 8);
+  return join(dir, `${base}-${stamp}-${rand}.md`);
+}
+
+// --- args parsing ---
+let input = null;
+let outPath = null;
+let writeTmp = false;
+let doSummary = false;
+let summaryPrompt = null;
+
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+
+  if (a === '--out') {
+    outPath = argv[i + 1] ?? null;
+    if (!outPath || isFlag(outPath)) {
+      console.error('Expected a value after --out');
+      process.exit(1);
+    }
+    i++;
+    continue;
+  }
+
+  if (a === '--tmp') {
+    writeTmp = true;
+    continue;
+  }
+
+  if (a === '--prompt' || a === '--summary-prompt') {
+    summaryPrompt = argv[i + 1] ?? null;
+    if (!summaryPrompt || isFlag(summaryPrompt)) {
+      console.error(`Expected a value after ${a}`);
+      process.exit(1);
+    }
+    i++;
+    continue;
+  }
+
+  if (a === '--summary') {
+    doSummary = true;
+
+    // Allow: --summary "extra instructions" (only if next token isn't a flag and input is already known)
+    const next = argv[i + 1];
+    if (input && next && !isFlag(next) && summaryPrompt == null) {
+      summaryPrompt = next;
+      i++;
+    }
+    continue;
+  }
+
+  if (isFlag(a)) {
+    console.error(`Unknown flag: ${a}`);
+    usageAndExit(1);
+  }
+
+  if (!input) {
+    input = a;
+  } else {
+    // Extra bare arg. If summary is enabled and no prompt yet, treat as prompt for convenience.
+    if (doSummary && summaryPrompt == null) {
+      summaryPrompt = a;
+    } else {
+      console.error(`Unexpected argument: ${a}`);
+      usageAndExit(1);
+    }
+  }
+}
+
+if (!input) usageAndExit(1);
+
+function runMarkitdown(arg) {
+  // Include PDF support by default because many document URLs (for example arXiv PDFs)
+  // are detected as PDFs only after fetching, so extension-based switching is unreliable.
+  const result = spawnSync('uvx', ['--from', 'markitdown[pdf]', 'markitdown', arg], {
+    encoding: 'utf-8',
+    maxBuffer: 50 * 1024 * 1024
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to run uvx markitdown: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    throw new Error(`markitdown failed for ${arg}${stderr ? `\n${stderr}` : ''}`);
+  }
+  return result.stdout;
+}
+
+function summarizeWithPi(markdown, { mdPathForNote = null, extraPrompt = null } = {}) {
+  const MAX_CHARS = 140_000;
+  let truncated = false;
+  let body = markdown;
+  if (body.length > MAX_CHARS) {
+    // Keep start + end for better summaries.
+    const head = body.slice(0, 110_000);
+    const tail = body.slice(-20_000);
+    body = `${head}\n\n[...TRUNCATED ${body.length - (head.length + tail.length)} chars...]\n\n${tail}`;
+    truncated = true;
+  }
+
+  const note = mdPathForNote ? `\n\n(Generated markdown file: ${mdPathForNote})\n` : '';
+  const truncNote = truncated ? '\n\nNote: Input was truncated due to size.' : '';
+
+  const contextBlock = extraPrompt
+    ? `\n\nUser-provided context / instructions (follow these closely):\n${extraPrompt}\n`
+    : `\n\nNo extra context was provided. If the summary seems misaligned, ask the user for what to focus on (goals, audience, what to extract).\n`;
+
+  const prompt = `You are summarizing a document that has been converted to Markdown.${note}
+${contextBlock}
+Please produce:
+- A short 1-paragraph executive summary
+- 8-15 bullet points of key facts / decisions / requirements
+- A section "Open questions / missing info" (bullets)
+
+Be concise. Preserve important numbers, names, and constraints.
+${truncNote}
+
+--- BEGIN DOCUMENT (Markdown) ---
+${body}
+--- END DOCUMENT ---`;
+
+  const result = spawnSync('pi', [
+    '--provider', 'anthropic',
+    '--model', 'claude-haiku-4-5',
+    '--no-tools',
+    '--no-session',
+    '-p',
+    prompt
+  ], {
+    encoding: 'utf-8',
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 120_000
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to run pi: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    throw new Error(`pi failed${stderr ? `\n${stderr}` : ''}`);
+  }
+  return (result.stdout || '').trim();
+}
+
+async function main() {
+  if (!isUrl(input) && !existsSync(input)) {
+    throw new Error(`File not found: ${input}`);
+  }
+
+  const md = runMarkitdown(input);
+
+  // If the user requested an explicit output file, write it there.
+  if (outPath) {
+    writeFileSync(outPath, md, 'utf-8');
+  }
+
+  // When summarizing we *always* write a temp markdown file and always return its path as a hint.
+  // When --tmp is passed, we write a temp file as well.
+  let tmpMdPath = null;
+  if (writeTmp || doSummary) {
+    tmpMdPath = makeTmpMdPath(input);
+    writeFileSync(tmpMdPath, md, 'utf-8');
+  }
+
+  if (writeTmp && tmpMdPath) {
+    // When only asked for tmp path, print path and exit.
+    if (!doSummary && !outPath) {
+      console.log(tmpMdPath);
+      return;
+    }
+  }
+
+  if (doSummary) {
+    const summary = summarizeWithPi(md, { mdPathForNote: tmpMdPath ?? outPath, extraPrompt: summaryPrompt });
+    process.stdout.write(summary);
+    if (tmpMdPath) {
+      process.stdout.write(`\n\n[Hint: Full document Markdown saved to: ${tmpMdPath}]\n`);
+    }
+    return;
+  }
+
+  process.stdout.write(md);
+}
+
+main().catch(err => {
+  console.error(err?.message || String(err));
+  process.exit(1);
+});

--- a/agents/skills/test-driven-development/SKILL.md
+++ b/agents/skills/test-driven-development/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: test-driven-development
+description: Enforces RED-GREEN-REFACTOR test-driven development. Use when implementing features, fixing bugs, or writing any code. Triggers on phrases like "implement this", "add a feature", "write code for", "fix this bug", "TDD", "write tests first". Never write implementation code before a failing test exists — always enforce this order regardless of how the request is phrased.
+---
+
+# Test-Driven Development
+
+**Announce:** "I'm using the test-driven-development skill. I'll write a failing test before any implementation."
+
+## The Cycle
+
+```
+RED → write failing test → verify it fails for the RIGHT reason
+GREEN → write minimal code to pass → verify it passes
+REFACTOR → clean up → keep all tests green
+REPEAT
+```
+
+## RED Phase
+
+Write ONE minimal test that captures the desired behavior. Show it to the user. The test must:
+- Test a single behavior
+- Have a descriptive name (no "and" — if you need "and", split it)
+- Fail because the code doesn't exist yet, not because of a syntax error
+
+```python
+# Example
+def test_retries_failed_operation_three_times():
+    attempts = []
+    def flaky():
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise RuntimeError("not yet")
+        return "ok"
+    assert retry(flaky) == "ok"
+    assert len(attempts) == 3
+```
+
+Show the expected failure output. Ask the user to run it and confirm it fails.
+
+## GREEN Phase
+
+Write the **minimal** code that makes the test pass. No extras. No "while I'm here" improvements. If the test passes, confirm with the user before moving on.
+
+## REFACTOR Phase
+
+Clean up duplication, naming, structure — without adding behavior. Run tests after each change. If anything goes red, revert immediately.
+
+## Rules
+
+- **Test fails for wrong reason?** Fix the test, not by adding code — go back to RED.
+- **Bug found?** Write a failing test that reproduces it first. Never fix bugs without a test.
+- **Code written before a test?** Delete it. Start over. The sunk cost is already gone.
+- **"I'll write tests after"?** No. Tests-after prove nothing — you already know it works.
+
+## Checklist Before Moving to Next Task
+
+- [ ] Test was written and confirmed failing before implementation
+- [ ] Implementation is minimal (nothing beyond what the test requires)  
+- [ ] All tests passing
+- [ ] Code committed

--- a/agents/skills/tmux/SKILL.md
+++ b/agents/skills/tmux/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: tmux
+description: "Spawn and drive tmux sessions from the agent — background long-lived processes (dev servers, watchers) and interact with REPLs/TUIs (python, ipython, debuggers). Always use the dedicated `agent` socket so user sessions are untouched."
+---
+
+# Tmux Skill
+
+Use tmux when a regular `bash` tool call won't do, specifically:
+
+- **Long-lived processes** that must keep running across turns
+  (dev servers, file watchers, `cargo watch`, log followers).
+- **Interactive REPLs / TUIs** where state must persist between
+  inputs (python, ipython, node, gdb/lldb, `psql`, etc.).
+
+For anything that finishes on its own in a reasonable time, just use
+`bash` — don't reach for tmux.
+
+## Isolation: always use the `agent` socket
+
+Every tmux command in this skill uses `-L agent`. This puts the
+agent's sessions on a separate tmux server from whatever the user is
+running, so we can't accidentally kill or read their panes.
+
+```bash
+alias t='tmux -L agent'   # mental model only; use the full flag in commands
+```
+
+Never run plain `tmux ...` — always `tmux -L agent ...`.
+
+## Naming
+
+Pick short, descriptive session names: `dev`, `build`, `py`, `pg`.
+One concern per session. If you need multiples, suffix:
+`dev-api`, `dev-web`.
+
+## Core verbs
+
+### Start a detached session running a command
+
+```bash
+tmux -L agent new-session -d -s dev -- npm run dev
+```
+
+- `-d` detached (don't attach)
+- `-s NAME` session name
+- `--` everything after is the command (no shell quoting surprises)
+
+If the command exits, the session ends. To keep the pane alive after
+the command exits (useful when debugging why it died), start a shell
+and send the command separately (see next).
+
+### Start an empty shell session, then send commands
+
+```bash
+tmux -L agent new-session -d -s py
+tmux -L agent send-keys -t py 'python3 -i' Enter
+```
+
+Use this when you want a persistent REPL you'll drive interactively.
+
+### Send input to a session
+
+`send-keys` takes a string and/or named keys as separate arguments.
+**`Enter` is its own argument** — it does not work to append `\n`.
+
+```bash
+tmux -L agent send-keys -t py 'x = 1 + 1' Enter
+tmux -L agent send-keys -t dev C-c              # interrupt
+tmux -L agent send-keys -t dev 'q'              # no Enter (single keystroke)
+```
+
+For strings that contain characters tmux would interpret as keys (e.g.
+`;`, `Space`, things that look like key names), use `-l` for literal:
+
+```bash
+tmux -L agent send-keys -t py -l 'print("hello; world")'
+tmux -L agent send-keys -t py Enter
+```
+
+### Capture pane output
+
+`capture-pane -p` prints to stdout. Use `-S` to include scrollback:
+
+```bash
+tmux -L agent capture-pane -t py -p              # visible pane only
+tmux -L agent capture-pane -t py -p -S -         # full scrollback
+tmux -L agent capture-pane -t py -p -S -200      # last 200 lines
+```
+
+For long sessions, prefer logging to a file (next section) and `tail`
+that instead of repeatedly capturing.
+
+### Continuous logging with `pipe-pane`
+
+Mirror everything the pane prints to a file. Set this up immediately
+after creating the session:
+
+```bash
+tmux -L agent new-session -d -s build
+tmux -L agent pipe-pane  -t build -o 'cat >>/tmp/agent-build.log'
+tmux -L agent send-keys  -t build 'npm run build:watch' Enter
+```
+
+Now you can `tail -n 50 /tmp/agent-build.log` or `grep ERROR` it from
+later turns without disturbing the pane. `-o` means "only open the
+pipe if not already open", making the call idempotent.
+
+Clean up the log file when killing the session.
+
+### List what's running
+
+```bash
+tmux -L agent list-sessions                       # sessions
+tmux -L agent list-windows -t dev                 # windows in a session
+tmux -L agent list-panes   -t dev -F '#{pane_pid} #{pane_current_command}'
+```
+
+If `list-sessions` errors with "no server running", there are no
+agent sessions — that's a normal state, not a failure.
+
+### Kill things
+
+```bash
+tmux -L agent kill-session -t dev
+tmux -L agent kill-server                         # nuke ALL agent sessions
+```
+
+Always kill sessions you started once you're done with them. Leaving
+orphans behind is the main way this skill goes wrong.
+
+## Patterns
+
+### Run a dev server in the background, then check its output
+
+```bash
+tmux -L agent new-session -d -s dev
+tmux -L agent pipe-pane  -t dev -o 'cat >>/tmp/agent-dev.log'
+tmux -L agent send-keys  -t dev 'npm run dev' Enter
+
+# ...do other work...
+
+sleep 2
+tail -n 100 /tmp/agent-dev.log
+```
+
+### Drive a Python REPL
+
+```bash
+tmux -L agent new-session -d -s py
+tmux -L agent send-keys   -t py 'python3 -i' Enter
+sleep 0.3
+
+tmux -L agent send-keys   -t py -l 'import json; data = json.load(open("x.json"))'
+tmux -L agent send-keys   -t py Enter
+tmux -L agent send-keys   -t py -l 'len(data)'
+tmux -L agent send-keys   -t py Enter
+sleep 0.3
+tmux -L agent capture-pane -t py -p -S -
+```
+
+### Know when a command has finished (sentinel pattern)
+
+tmux is asynchronous: `send-keys` returns immediately, before the
+command runs. If you need to wait for completion, append a sentinel
+and poll:
+
+```bash
+tmux -L agent send-keys -t dev 'long_command; echo __AGENT_DONE_$$__' Enter
+
+for i in $(seq 1 30); do
+  if tmux -L agent capture-pane -t dev -p -S - | grep -q '__AGENT_DONE_'; then
+    break
+  fi
+  sleep 1
+done
+
+tmux -L agent capture-pane -t dev -p -S -
+```
+
+Skip this for fire-and-forget servers — they never "finish".
+
+## Worked example: dev server with readiness check and cleanup
+
+A realistic flow that exercises most of this skill: start a Vite dev
+server, wait until it is actually serving, do some work, later check
+the log for errors introduced by edits, then shut everything down.
+
+```bash
+# 1. Start from a clean slate (idempotent — safe to re-run).
+tmux -L agent kill-session -t dev 2>/dev/null
+rm -f /tmp/agent-dev.log
+
+# 2. Create the session, attach a log, then start the server.
+#    Doing pipe-pane BEFORE send-keys ensures we capture startup output.
+tmux -L agent new-session -d -s dev
+tmux -L agent pipe-pane  -t dev -o 'cat >>/tmp/agent-dev.log'
+tmux -L agent send-keys  -t dev 'npm run dev' Enter
+
+# 3. Wait for readiness. Poll the log for Vite's "ready in" banner
+#    instead of a blind sleep — fast when it's fast, patient when it isn't.
+for i in $(seq 1 30); do
+  grep -q 'ready in' /tmp/agent-dev.log && break
+  sleep 1
+done
+
+if ! grep -q 'ready in' /tmp/agent-dev.log; then
+  echo 'dev server did not start in 30s; last log lines:'
+  tail -n 50 /tmp/agent-dev.log
+  tmux -L agent kill-session -t dev
+  exit 1
+fi
+
+# 4. ...go off and edit files in other tool calls...
+
+# 5. After edits, look for new errors. Track a byte offset so we only
+#    inspect output produced since the last check.
+MARK=$(wc -c </tmp/agent-dev.log)
+# ...make another edit...
+tail -c +$((MARK + 1)) /tmp/agent-dev.log | grep -E 'error|Error|ERROR' \
+  || echo 'no new errors'
+
+# 6. Tear down. Kill the session AND remove the log file.
+tmux -L agent kill-session -t dev
+rm -f /tmp/agent-dev.log
+```
+
+Key things this example demonstrates:
+
+- `kill-session` + `rm` at the top makes the whole block re-runnable.
+- `pipe-pane` is set up **before** `send-keys` so startup output is
+  not lost.
+- Readiness is detected by **grepping for a known string**, not a
+  fixed sleep — robust to slow machines and fast ones.
+- A byte offset (`wc -c` → `tail -c +N`) lets later turns scan only
+  *new* log output, avoiding false positives from earlier runs.
+- Cleanup removes both the tmux session and the on-disk log.
+
+## Pitfalls
+
+- **Forgetting `Enter`.** `send-keys 'cmd'` types the text but doesn't
+  run it. Always pass `Enter` as a separate argument when you want
+  execution.
+- **Quoting strings with `;`, `Space`, or anything that looks like a
+  key name.** Use `send-keys -l` (literal mode) when in doubt.
+- **Capturing too early.** The command may not have produced output
+  yet. `sleep` briefly, or use the sentinel pattern.
+- **Targeting the wrong server.** If `-L agent` is missing, you're
+  poking the user's tmux. Always include it.
+- **Leaving sessions running.** Kill what you started; `tmux -L agent
+  list-sessions` at the end of a task is a cheap sanity check.
+- **Assuming the session exists.** Before `send-keys`, either create
+  the session in the same turn or check with `has-session`:
+
+  ```bash
+  tmux -L agent has-session -t dev 2>/dev/null || \
+    tmux -L agent new-session -d -s dev
+  ```

--- a/agents/skills/using-git-worktrees/SKILL.md
+++ b/agents/skills/using-git-worktrees/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: using-git-worktrees
+description: Creates and manages isolated git worktrees for feature development. Use when starting a new feature, working on a plan, or any time development work should be isolated from the main branch. Triggers on "start working on", "new feature", "create a branch", "implement the plan", or after a design/spec has been approved. Always set up a worktree before implementation begins.
+---
+
+# Using Git Worktrees
+
+**Announce:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
+
+Worktrees let you work on a feature branch in a separate directory without disturbing your main working tree. Each feature gets its own directory and branch.
+
+## Setup (run these commands)
+
+```bash
+# 1. Make sure your main branch is clean
+git status
+
+# 2. Create a worktree for the feature
+git worktree add ../project-feature-name feature/feature-name
+# This creates: a new directory at ../project-feature-name
+#               a new branch: feature/feature-name
+
+# 3. Move into the worktree
+cd ../project-feature-name
+
+# 4. Run your project setup (install deps, etc.)
+# e.g.: npm install / pip install -r requirements.txt / bundle install
+
+# 5. Verify tests pass before touching anything
+# e.g.: pytest / npm test / rails test
+```
+
+## Naming Convention
+
+- Directory: `../project-<feature-name>` (sibling of your main project dir)
+- Branch: `feature/<feature-name>` or `fix/<bug-name>`
+
+## Working in the Worktree
+
+All development happens in the worktree directory. Your main branch directory is untouched. You can switch between them freely.
+
+```bash
+# Check which worktrees exist
+git worktree list
+
+# Remove a worktree when done (after merge)
+cd ../project-main
+git worktree remove ../project-feature-name
+git branch -d feature/feature-name
+```
+
+## Checklist Before Starting Work
+
+- [ ] Main branch is clean (`git status` shows nothing uncommitted)
+- [ ] Worktree created on a new branch
+- [ ] Dependencies installed in worktree
+- [ ] Test suite passes in clean state (baseline confirmed)

--- a/agents/skills/web-browser/SKILL.md
+++ b/agents/skills/web-browser/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: web-browser
+description: "Allows to interact with web pages by performing actions such as clicking buttons, filling out forms, and navigating links. It works by remote controlling Google Chrome or Chromium browsers using the Chrome DevTools Protocol (CDP). When Claude needs to browse the web, it can use this skill to do so."
+license: Stolen from Mario
+---
+
+# Web Browser Skill
+
+Minimal CDP tools for collaborative site exploration.
+
+## Start Chrome
+
+```bash
+./scripts/start.js              # Fresh profile
+./scripts/start.js --profile    # Copy your profile (cookies, logins)
+```
+
+Start Chrome on `:9222` with remote debugging.
+
+If Chrome is installed in a non-standard location, set:
+
+```bash
+BROWSER_BIN=/path/to/chrome ./scripts/start.js
+```
+
+## Navigate
+
+```bash
+./scripts/nav.js https://example.com
+./scripts/nav.js https://example.com --new
+```
+
+Navigate current tab or open new tab.
+
+## Evaluate JavaScript
+
+```bash
+./scripts/eval.js 'document.title'
+./scripts/eval.js 'document.querySelectorAll("a").length'
+./scripts/eval.js 'JSON.stringify(Array.from(document.querySelectorAll("a")).map(a => ({ text: a.textContent.trim(), href: a.href })).filter(link => !link.href.startsWith("https://")))'
+```
+
+Execute JavaScript in active tab (async context).  Be careful with string escaping, best to use single quotes.
+
+## Screenshot
+
+```bash
+./scripts/screenshot.js
+```
+
+Screenshot current viewport, returns temp file path
+
+## Pick Elements
+
+```bash
+./scripts/pick.js "Click the submit button"
+```
+
+Interactive element picker. Click to select, Cmd/Ctrl+Click for multi-select, Enter to finish.
+
+## Dismiss Cookie Dialogs
+
+```bash
+./scripts/dismiss-cookies.js          # Accept cookies
+./scripts/dismiss-cookies.js --reject # Reject cookies (where possible)
+```
+
+Automatically dismisses EU cookie consent dialogs.
+
+Run after navigating to a page:
+```bash
+./scripts/nav.js https://example.com && ./scripts/dismiss-cookies.js
+```
+
+## Background Logging (Console + Errors + Network)
+
+Automatically started by `start.js` and writes JSONL logs to:
+
+```
+~/.cache/agent-web/logs/YYYY-MM-DD/<targetId>.jsonl
+```
+
+Manually start:
+```bash
+./scripts/watch.js
+```
+
+Tail latest log:
+```bash
+./scripts/logs-tail.js           # dump current log and exit
+./scripts/logs-tail.js --follow  # keep following
+```
+
+Summarize network responses:
+```bash
+./scripts/net-summary.js
+```

--- a/agents/skills/web-browser/scripts/cdp.js
+++ b/agents/skills/web-browser/scripts/cdp.js
@@ -1,0 +1,210 @@
+/**
+ * Minimal CDP client - no puppeteer, no hangs
+ */
+
+import WebSocket from "ws";
+
+export async function connect(timeout = 5000) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const resp = await fetch("http://localhost:9222/json/version", {
+      signal: controller.signal,
+    });
+    const { webSocketDebuggerUrl } = await resp.json();
+    clearTimeout(timeoutId);
+
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(webSocketDebuggerUrl);
+      const connectTimeout = setTimeout(() => {
+        ws.close();
+        reject(new Error("WebSocket connect timeout"));
+      }, timeout);
+
+      ws.on("open", () => {
+        clearTimeout(connectTimeout);
+        resolve(new CDP(ws));
+      });
+      ws.on("error", (e) => {
+        clearTimeout(connectTimeout);
+        reject(e);
+      });
+    });
+  } catch (e) {
+    clearTimeout(timeoutId);
+    if (e.name === "AbortError") {
+      throw new Error("Connection timeout - is Chrome running with --remote-debugging-port=9222?");
+    }
+    throw e;
+  }
+}
+
+class CDP {
+  constructor(ws) {
+    this.ws = ws;
+    this.id = 0;
+    this.callbacks = new Map();
+    this.sessions = new Map();
+    this.eventHandlers = new Map();
+
+    ws.on("message", (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.id && this.callbacks.has(msg.id)) {
+        const { resolve, reject } = this.callbacks.get(msg.id);
+        this.callbacks.delete(msg.id);
+        if (msg.error) {
+          reject(new Error(msg.error.message));
+        } else {
+          resolve(msg.result);
+        }
+        return;
+      }
+
+      if (msg.method) {
+        this.emit(msg.method, msg.params || {}, msg.sessionId || null);
+      }
+    });
+  }
+
+  on(method, handler) {
+    if (!this.eventHandlers.has(method)) {
+      this.eventHandlers.set(method, new Set());
+    }
+    this.eventHandlers.get(method).add(handler);
+    return () => this.off(method, handler);
+  }
+
+  off(method, handler) {
+    const handlers = this.eventHandlers.get(method);
+    if (!handlers) return;
+    handlers.delete(handler);
+    if (handlers.size === 0) {
+      this.eventHandlers.delete(method);
+    }
+  }
+
+  emit(method, params, sessionId) {
+    const handlers = this.eventHandlers.get(method);
+    if (!handlers || handlers.size === 0) return;
+    for (const handler of handlers) {
+      try {
+        handler(params, sessionId);
+      } catch {
+        // Ignore handler errors to keep CDP session alive.
+      }
+    }
+  }
+
+  send(method, params = {}, sessionId = null, timeout = 10000) {
+    return new Promise((resolve, reject) => {
+      const msgId = ++this.id;
+      const msg = { id: msgId, method, params };
+      if (sessionId) msg.sessionId = sessionId;
+
+      const timeoutId = setTimeout(() => {
+        this.callbacks.delete(msgId);
+        reject(new Error(`CDP timeout: ${method}`));
+      }, timeout);
+
+      this.callbacks.set(msgId, {
+        resolve: (result) => {
+          clearTimeout(timeoutId);
+          resolve(result);
+        },
+        reject: (err) => {
+          clearTimeout(timeoutId);
+          reject(err);
+        },
+      });
+
+      this.ws.send(JSON.stringify(msg));
+    });
+  }
+
+  async getPages() {
+    const { targetInfos } = await this.send("Target.getTargets");
+    return targetInfos.filter((t) => t.type === "page");
+  }
+
+  async attachToPage(targetId) {
+    const { sessionId } = await this.send("Target.attachToTarget", {
+      targetId,
+      flatten: true,
+    });
+    return sessionId;
+  }
+
+  async evaluate(sessionId, expression, timeout = 30000) {
+    const result = await this.send(
+      "Runtime.evaluate",
+      {
+        expression,
+        returnByValue: true,
+        awaitPromise: true,
+      },
+      sessionId,
+      timeout
+    );
+
+    if (result.exceptionDetails) {
+      throw new Error(
+        result.exceptionDetails.exception?.description ||
+          result.exceptionDetails.text
+      );
+    }
+    return result.result?.value;
+  }
+
+  async screenshot(sessionId, timeout = 10000) {
+    const { data } = await this.send(
+      "Page.captureScreenshot",
+      { format: "png" },
+      sessionId,
+      timeout
+    );
+    return Buffer.from(data, "base64");
+  }
+
+  async navigate(sessionId, url, timeout = 30000) {
+    await this.send("Page.navigate", { url }, sessionId, timeout);
+  }
+
+  async getFrameTree(sessionId) {
+    const { frameTree } = await this.send("Page.getFrameTree", {}, sessionId);
+    return frameTree;
+  }
+
+  async evaluateInFrame(sessionId, frameId, expression, timeout = 30000) {
+    // Create isolated world for the frame
+    const { executionContextId } = await this.send(
+      "Page.createIsolatedWorld",
+      { frameId, worldName: "cdp-eval" },
+      sessionId
+    );
+
+    const result = await this.send(
+      "Runtime.evaluate",
+      {
+        expression,
+        contextId: executionContextId,
+        returnByValue: true,
+        awaitPromise: true,
+      },
+      sessionId,
+      timeout
+    );
+
+    if (result.exceptionDetails) {
+      throw new Error(
+        result.exceptionDetails.exception?.description ||
+          result.exceptionDetails.text
+      );
+    }
+    return result.result?.value;
+  }
+
+  close() {
+    this.ws.close();
+  }
+}

--- a/agents/skills/web-browser/scripts/dismiss-cookies.js
+++ b/agents/skills/web-browser/scripts/dismiss-cookies.js
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+
+/**
+ * Cookie Consent Dismissal Helper
+ *
+ * Automatically accepts cookie consent dialogs on EU websites.
+ * Supports common CMPs: OneTrust, Cookiebot, Didomi, Quantcast, Google, BBC, Amazon, etc.
+ *
+ * Usage:
+ *   ./dismiss-cookies.js          # Accept cookies
+ *   ./dismiss-cookies.js --reject # Reject cookies (where possible)
+ */
+
+import { connect } from "./cdp.js";
+
+const DEBUG = process.env.DEBUG === "1";
+const log = DEBUG ? (...args) => console.error("[debug]", ...args) : () => {};
+
+const reject = process.argv.includes("--reject");
+const mode = reject ? "reject" : "accept";
+
+const COOKIE_DISMISS_SCRIPT = `(acceptCookies) => {
+  const clicked = [];
+
+  const isVisible = (el) => {
+    if (!el) return false;
+    const style = getComputedStyle(el);
+    return style.display !== 'none' && 
+           style.visibility !== 'hidden' && 
+           style.opacity !== '0' &&
+           (el.offsetParent !== null || style.position === 'fixed' || style.position === 'sticky');
+  };
+
+  const tryClick = (selector, description) => {
+    const el = typeof selector === 'string' ? document.querySelector(selector) : selector;
+    if (isVisible(el)) {
+      el.click();
+      clicked.push(description || selector);
+      return true;
+    }
+    return false;
+  };
+
+  const findButtonByText = (patterns, container = document) => {
+    const buttons = Array.from(container.querySelectorAll('button, [role="button"], a.button, input[type="submit"], input[type="button"]'));
+    // Sort patterns by length descending to match more specific patterns first
+    const sortedPatterns = [...patterns].sort((a, b) => b.length - a.length);
+    
+    // Check patterns in order of specificity (longest first)
+    for (const pattern of sortedPatterns) {
+      for (const btn of buttons) {
+        const text = (btn.textContent || btn.value || '').trim().toLowerCase();
+        if (text.length > 100) continue; // Skip buttons with very long text
+        if (!isVisible(btn)) continue; // Skip hidden buttons
+        if (typeof pattern === 'string' ? text.includes(pattern) : pattern.test(text)) {
+          return btn;
+        }
+      }
+    }
+    return null;
+  };
+  
+  const acceptPatterns = [
+    'accept all', 'accept cookies', 'allow all', 'allow cookies',
+    'i agree', 'i accept', 'yes, i agree', 'agree and continue',
+    'alle akzeptieren', 'akzeptieren', 'alle zulassen', 'zustimmen',
+    'annehmen', 'einverstanden',
+    'accepter tout', 'tout accepter', "j'accepte", 'accepter et continuer', 'accepter',
+    'accetta tutti', 'accetta', 'accetto',
+    'aceptar todo', 'aceptar', 'acepto',
+    'aceitar tudo', 'aceitar',
+    'continue', 'agree',
+  ];
+
+  const rejectPatterns = [
+    'reject all', 'decline all', 'deny all', 'refuse all',
+    'i do not agree', 'i disagree', 'no thanks',
+    'alle ablehnen', 'ablehnen', 'nicht zustimmen',
+    'refuser tout', 'tout refuser', 'refuser',
+    'rifiuta tutti', 'rifiuta',
+    'rechazar todo', 'rechazar',
+    'rejeitar tudo', 'rejeitar',
+    'only necessary', 'necessary only', 'nur notwendige',
+    'essential only', 'nur essentielle',
+  ];
+
+  const patterns = acceptCookies ? acceptPatterns : rejectPatterns;
+
+  // OneTrust
+  if (document.querySelector('#onetrust-banner-sdk')) {
+    const selector = acceptCookies ? '#onetrust-accept-btn-handler' : '#onetrust-reject-all-handler';
+    if (tryClick(selector, 'OneTrust')) return clicked;
+  }
+
+  // Google
+  if (document.querySelector('[data-consent-dialog]') || document.querySelector('form[action*="consent.google"]') || document.querySelector('#CXQnmb')) {
+    const selector = acceptCookies ? '#L2AGLb' : '#W0wltc';
+    if (tryClick(selector, 'Google Consent')) return clicked;
+  }
+
+  // YouTube (Google-owned, custom consent element)
+  if (document.querySelector('ytd-consent-bump-v2-lightbox')) {
+    const btn = Array.from(document.querySelectorAll('ytd-consent-bump-v2-lightbox button'))
+      .find(b => acceptCookies 
+        ? b.textContent.includes('Accept all') || b.ariaLabel?.includes('Accept')
+        : b.textContent.includes('Reject all') || b.ariaLabel?.includes('Reject'));
+    if (btn) {
+      btn.click();
+      clicked.push('YouTube');
+      return clicked;
+    }
+  }
+
+  // Cookiebot
+  if (document.querySelector('#CybotCookiebotDialog')) {
+    const selector = acceptCookies
+      ? '#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll, #CybotCookiebotDialogBodyButtonAccept'
+      : '#CybotCookiebotDialogBodyButtonDecline, #CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll';
+    if (tryClick(selector, 'Cookiebot')) return clicked;
+  }
+
+  // Didomi
+  if (document.querySelector('#didomi-host') || window.Didomi) {
+    const selector = acceptCookies ? '#didomi-notice-agree-button' : '#didomi-notice-disagree-button, [data-testid="disagree-button"]';
+    if (tryClick(selector, 'Didomi')) return clicked;
+  }
+
+  // Quantcast
+  if (document.querySelector('.qc-cmp2-container')) {
+    const selector = acceptCookies
+      ? '.qc-cmp2-summary-buttons button[mode="primary"], .qc-cmp2-button[data-testid="accept-all"]'
+      : '.qc-cmp2-summary-buttons button[mode="secondary"], .qc-cmp2-button[data-testid="reject-all"]';
+    if (tryClick(selector, 'Quantcast')) return clicked;
+  }
+
+  // Usercentrics (shadow DOM)
+  const ucRoot = document.querySelector('#usercentrics-root');
+  if (ucRoot && ucRoot.shadowRoot) {
+    const shadow = ucRoot.shadowRoot;
+    const btn = acceptCookies
+      ? shadow.querySelector('[data-testid="uc-accept-all-button"]')
+      : shadow.querySelector('[data-testid="uc-deny-all-button"]');
+    if (btn) { btn.click(); clicked.push('Usercentrics'); return clicked; }
+  }
+
+  // TrustArc
+  if (document.querySelector('#truste-consent-track') || document.querySelector('.trustarc-banner')) {
+    const selector = acceptCookies ? '#truste-consent-button, .trustarc-agree-btn' : '.trustarc-decline-btn';
+    if (tryClick(selector, 'TrustArc')) return clicked;
+  }
+
+  // Klaro
+  if (document.querySelector('.klaro')) {
+    const selector = acceptCookies ? '.klaro .cm-btn-accept-all, .klaro .cm-btn-success' : '.klaro .cm-btn-decline';
+    if (tryClick(selector, 'Klaro')) return clicked;
+  }
+
+  // BBC
+  if (document.querySelector('#bbccookies, .bbccookies-banner')) {
+    if (acceptCookies && tryClick('#bbccookies-continue-button', 'BBC')) return clicked;
+  }
+
+  // Amazon
+  if (document.querySelector('#sp-cc') || document.querySelector('#sp-cc-accept')) {
+    const selector = acceptCookies ? '#sp-cc-accept' : '#sp-cc-rejectall-link, #sp-cc-decline';
+    if (tryClick(selector, 'Amazon')) return clicked;
+  }
+
+  // CookieYes
+  if (document.querySelector('#cookie-law-info-bar') || document.querySelector('.cky-consent-container')) {
+    const selector = acceptCookies ? '#cookie_action_close_header, .cky-btn-accept' : '.cky-btn-reject';
+    if (tryClick(selector, 'CookieYes')) return clicked;
+  }
+
+  // Generic containers
+  const consentContainers = [
+    '[class*="cookie-banner"]', '[class*="cookie-consent"]', '[class*="cookie-notice"]',
+    '[class*="cookieBanner"]', '[class*="cookieConsent"]', '[class*="cookieNotice"]',
+    '[id*="cookie-banner"]', '[id*="cookie-consent"]', '[id*="cookie-notice"]',
+    '[class*="consent-banner"]', '[class*="consent-modal"]', '[class*="consent-dialog"]',
+    '[class*="gdpr"]', '[id*="gdpr"]', '[class*="privacy-banner"]', '[class*="privacy-notice"]',
+    '[role="dialog"][aria-label*="cookie" i]', '[role="dialog"][aria-label*="consent" i]',
+  ];
+
+  for (const containerSel of consentContainers) {
+    const containers = document.querySelectorAll(containerSel);
+    for (const container of containers) {
+      if (!isVisible(container)) continue;
+      // Skip html/body elements that might match
+      if (container.tagName === 'HTML' || container.tagName === 'BODY') continue;
+      const btn = findButtonByText(patterns, container);
+      if (btn) { btn.click(); clicked.push('Generic (' + containerSel + ')'); return clicked; }
+    }
+  }
+
+  // Last resort: find button near cookie-related text content
+  // Look for visible containers that mention "cookie" and have accept/reject buttons
+  // Include custom elements (Reddit uses rpl-modal-card, etc.)
+  const allContainers = document.querySelectorAll('div, section, aside, [class*="modal"], [class*="dialog"], [role="dialog"]');
+  for (const container of allContainers) {
+    if (!isVisible(container)) continue;
+    const text = container.textContent?.toLowerCase() || '';
+    // Must mention cookies and be reasonably sized (not the whole page)
+    if (text.includes('cookie') && text.length > 100 && text.length < 3000) {
+      const btn = findButtonByText(patterns, container);
+      if (btn && isVisible(btn)) {
+        btn.click();
+        clicked.push('Generic (text-based)');
+        return clicked;
+      }
+    }
+  }
+
+  // Final fallback: look for any visible button with exact accept/reject text
+  // that appears alongside cookie-related content on the page
+  if (document.body.textContent?.toLowerCase().includes('cookie')) {
+    const exactPatterns = acceptCookies 
+      ? ['accept all', 'accept cookies', 'allow all', 'i agree', 'alle akzeptieren']
+      : ['reject all', 'decline all', 'reject optional', 'alle ablehnen'];
+    const singleWordPatterns = acceptCookies ? ['accept', 'agree'] : ['reject', 'decline'];
+    const buttons = document.querySelectorAll('button, [role="button"]');
+    for (const btn of buttons) {
+      if (!isVisible(btn)) continue;
+      const text = (btn.textContent || '').trim().toLowerCase();
+      if (exactPatterns.some(p => text.includes(p))) {
+        btn.click();
+        clicked.push('Generic (exact match)');
+        return clicked;
+      }
+    }
+    // Try single-word matches as last resort
+    for (const btn of buttons) {
+      if (!isVisible(btn)) continue;
+      const text = (btn.textContent || '').trim().toLowerCase();
+      if (singleWordPatterns.some(p => text === p)) {
+        btn.click();
+        clicked.push('Generic (single word)');
+        return clicked;
+      }
+    }
+  }
+
+  return clicked;
+}`;
+
+const IFRAME_DISMISS_SCRIPT = `(acceptCookies) => {
+  const clicked = [];
+
+  const isVisible = (el) => {
+    if (!el) return false;
+    const style = getComputedStyle(el);
+    return style.display !== 'none' && 
+           style.visibility !== 'hidden' && 
+           style.opacity !== '0' &&
+           (el.offsetParent !== null || style.position === 'fixed' || style.position === 'sticky');
+  };
+
+  const rejectIndicators = ['do not', "don't", 'nicht', 'no ', 'refuse', 'reject', 'decline', 'deny', 'disagree', 'ablehnen', 'refuser', 'rifiuta', 'rechazar', 'manage', 'settings', 'options', 'customize'];
+  const acceptIndicators = ['accept', 'agree', 'allow', 'yes', 'ok', 'got it', 'continue', 'akzeptieren', 'zustimmen', 'accepter', 'accetta', 'aceptar'];
+
+  const isRejectButton = (text) => rejectIndicators.some(p => text.includes(p));
+  const isAcceptButton = (text) => acceptIndicators.some(p => text.includes(p)) && !isRejectButton(text);
+
+  const buttons = document.querySelectorAll('button, [role="button"]');
+  for (const btn of buttons) {
+    const text = (btn.textContent || '').trim().toLowerCase();
+    if (!isVisible(btn)) continue;
+    const shouldClick = acceptCookies ? isAcceptButton(text) : isRejectButton(text);
+    if (shouldClick) { btn.click(); clicked.push('iframe: ' + text.slice(0, 30)); return clicked; }
+  }
+
+  const spBtn = acceptCookies
+    ? document.querySelector('[title="Accept All"], [title="Accept"], [aria-label*="Accept"]')
+    : document.querySelector('[title="Reject All"], [title="Reject"], [aria-label*="Reject"]');
+  if (spBtn) { spBtn.click(); clicked.push('Sourcepoint iframe'); return clicked; }
+
+  return clicked;
+}`;
+
+// Recursively collect all frames
+function collectFrames(frameTree, frames = []) {
+  frames.push({ id: frameTree.frame.id, url: frameTree.frame.url });
+  if (frameTree.childFrames) {
+    for (const child of frameTree.childFrames) {
+      collectFrames(child, frames);
+    }
+  }
+  return frames;
+}
+
+// Global timeout
+const globalTimeout = setTimeout(() => {
+  console.error("✗ Global timeout exceeded (30s)");
+  process.exit(1);
+}, 30000);
+
+try {
+  log("connecting...");
+  const cdp = await connect(5000);
+
+  log("getting pages...");
+  const pages = await cdp.getPages();
+  const page = pages.at(-1);
+
+  if (!page) {
+    console.error("✗ No active tab found");
+    process.exit(1);
+  }
+
+  log("attaching to page...");
+  const sessionId = await cdp.attachToPage(page.targetId);
+
+  // Wait a bit for consent dialogs to appear
+  await new Promise((r) => setTimeout(r, 500));
+
+  log("trying main page...");
+  let result = await cdp.evaluate(sessionId, `(${COOKIE_DISMISS_SCRIPT})(${!reject})`);
+
+  // If nothing found, try iframes
+  if (result.length === 0) {
+    log("trying iframes...");
+    try {
+      const frameTree = await cdp.getFrameTree(sessionId);
+      const frames = collectFrames(frameTree);
+
+      for (const frame of frames) {
+        if (frame.url === "about:blank" || frame.url.startsWith("javascript:")) continue;
+        if (
+          frame.url.includes("sp_message") ||
+          frame.url.includes("consent") ||
+          frame.url.includes("privacy") ||
+          frame.url.includes("cmp") ||
+          frame.url.includes("sourcepoint") ||
+          frame.url.includes("cookie") ||
+          frame.url.includes("privacy-mgmt")
+        ) {
+          log("trying frame:", frame.url.slice(0, 60));
+          try {
+            const frameResult = await cdp.evaluateInFrame(
+              sessionId,
+              frame.id,
+              `(${IFRAME_DISMISS_SCRIPT})(${!reject})`
+            );
+            if (frameResult.length > 0) {
+              result = frameResult;
+              break;
+            }
+          } catch (e) {
+            log("frame error:", e.message);
+          }
+        }
+      }
+    } catch (e) {
+      log("getFrameTree error:", e.message);
+    }
+  }
+
+  if (result.length > 0) {
+    console.log(`✓ Dismissed cookie dialog (${mode}): ${result.join(", ")}`);
+  } else {
+    console.log(`○ No cookie dialog found to ${mode}`);
+  }
+
+  log("closing...");
+  cdp.close();
+  log("done");
+} catch (e) {
+  console.error("✗", e.message);
+  process.exit(1);
+} finally {
+  clearTimeout(globalTimeout);
+  setTimeout(() => process.exit(0), 100);
+}

--- a/agents/skills/web-browser/scripts/eval.js
+++ b/agents/skills/web-browser/scripts/eval.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { connect } from "./cdp.js";
+
+const DEBUG = process.env.DEBUG === "1";
+const log = DEBUG ? (...args) => console.error("[debug]", ...args) : () => {};
+
+const code = process.argv.slice(2).join(" ");
+if (!code) {
+  console.log("Usage: eval.js 'code'");
+  console.log("\nExamples:");
+  console.log('  eval.js "document.title"');
+  console.log("  eval.js \"document.querySelectorAll('a').length\"");
+  process.exit(1);
+}
+
+// Global timeout
+const globalTimeout = setTimeout(() => {
+  console.error("✗ Global timeout exceeded (45s)");
+  process.exit(1);
+}, 45000);
+
+try {
+  log("connecting...");
+  const cdp = await connect(5000);
+
+  log("getting pages...");
+  const pages = await cdp.getPages();
+  const page = pages.at(-1);
+
+  if (!page) {
+    console.error("✗ No active tab found");
+    process.exit(1);
+  }
+
+  log("attaching to page...");
+  const sessionId = await cdp.attachToPage(page.targetId);
+
+  log("evaluating...");
+  const expression = `(async () => { return (${code}); })()`;
+  const result = await cdp.evaluate(sessionId, expression);
+
+  log("formatting result...");
+  if (Array.isArray(result)) {
+    for (let i = 0; i < result.length; i++) {
+      if (i > 0) console.log("");
+      for (const [key, value] of Object.entries(result[i])) {
+        console.log(`${key}: ${value}`);
+      }
+    }
+  } else if (typeof result === "object" && result !== null) {
+    for (const [key, value] of Object.entries(result)) {
+      console.log(`${key}: ${value}`);
+    }
+  } else {
+    console.log(result);
+  }
+
+  log("closing...");
+  cdp.close();
+  log("done");
+} catch (e) {
+  console.error("✗", e.message);
+  process.exit(1);
+} finally {
+  clearTimeout(globalTimeout);
+  setTimeout(() => process.exit(0), 100);
+}

--- a/agents/skills/web-browser/scripts/logs-tail.js
+++ b/agents/skills/web-browser/scripts/logs-tail.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync, watch } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const LOG_ROOT = join(homedir(), ".cache/agent-web/logs");
+
+function findLatestFile() {
+  if (!existsSync(LOG_ROOT)) return null;
+  const dirs = readdirSync(LOG_ROOT)
+    .filter((name) => /^\d{4}-\d{2}-\d{2}$/.test(name))
+    .map((name) => join(LOG_ROOT, name))
+    .filter((path) => statSafe(path)?.isDirectory())
+    .sort();
+  if (dirs.length === 0) return null;
+  const latestDir = dirs[dirs.length - 1];
+  const files = readdirSync(latestDir)
+    .filter((name) => name.endsWith(".jsonl"))
+    .map((name) => join(latestDir, name))
+    .map((path) => ({ path, mtime: statSafe(path)?.mtimeMs || 0 }))
+    .sort((a, b) => b.mtime - a.mtime);
+  return files[0]?.path || null;
+}
+
+function statSafe(path) {
+  try {
+    return statSync(path);
+  } catch {
+    return null;
+  }
+}
+
+const argIndex = process.argv.indexOf("--file");
+const filePath = argIndex !== -1 ? process.argv[argIndex + 1] : findLatestFile();
+const follow = process.argv.includes("--follow");
+
+if (!filePath) {
+  console.error("✗ No log file found");
+  process.exit(1);
+}
+
+function readAll() {
+  if (!existsSync(filePath)) return;
+  const data = readFileSync(filePath, "utf8");
+  if (data.length > 0) process.stdout.write(data);
+}
+
+let offset = 0;
+
+function readNew() {
+  if (!existsSync(filePath)) return;
+  const data = readFileSync(filePath, "utf8");
+  if (data.length <= offset) return;
+  const chunk = data.slice(offset);
+  offset = data.length;
+  process.stdout.write(chunk);
+}
+
+try {
+  readAll();
+  if (!follow) process.exit(0);
+  offset = statSafe(filePath)?.size || 0;
+  watch(filePath, { persistent: true }, () => readNew());
+  console.log(`✓ tailing ${filePath}`);
+} catch (e) {
+  console.error("✗ tail failed:", e.message);
+  process.exit(1);
+}

--- a/agents/skills/web-browser/scripts/nav.js
+++ b/agents/skills/web-browser/scripts/nav.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { connect } from "./cdp.js";
+
+const DEBUG = process.env.DEBUG === "1";
+const log = DEBUG ? (...args) => console.error("[debug]", ...args) : () => {};
+
+const url = process.argv[2];
+const newTab = process.argv[3] === "--new";
+
+if (!url) {
+  console.log("Usage: nav.js <url> [--new]");
+  console.log("\nExamples:");
+  console.log("  nav.js https://example.com       # Navigate current tab");
+  console.log("  nav.js https://example.com --new # Open in new tab");
+  process.exit(1);
+}
+
+// Global timeout
+const globalTimeout = setTimeout(() => {
+  console.error("✗ Global timeout exceeded (45s)");
+  process.exit(1);
+}, 45000);
+
+try {
+  log("connecting...");
+  const cdp = await connect(5000);
+
+  log("getting pages...");
+  let targetId;
+
+  if (newTab) {
+    log("creating new tab...");
+    const { targetId: newTargetId } = await cdp.send("Target.createTarget", {
+      url: "about:blank",
+    });
+    targetId = newTargetId;
+  } else {
+    const pages = await cdp.getPages();
+    const page = pages.at(-1);
+    if (!page) {
+      console.error("✗ No active tab found");
+      process.exit(1);
+    }
+    targetId = page.targetId;
+  }
+
+  log("attaching to page...");
+  const sessionId = await cdp.attachToPage(targetId);
+
+  log("navigating...");
+  await cdp.navigate(sessionId, url);
+
+  console.log(newTab ? "✓ Opened:" : "✓ Navigated to:", url);
+
+  log("closing...");
+  cdp.close();
+  log("done");
+} catch (e) {
+  console.error("✗", e.message);
+  process.exit(1);
+} finally {
+  clearTimeout(globalTimeout);
+  setTimeout(() => process.exit(0), 100);
+}

--- a/agents/skills/web-browser/scripts/net-summary.js
+++ b/agents/skills/web-browser/scripts/net-summary.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const LOG_ROOT = join(homedir(), ".cache/agent-web/logs");
+
+function statSafe(path) {
+  try {
+    return statSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function findLatestFile() {
+  if (!existsSync(LOG_ROOT)) return null;
+  const dirs = readdirSync(LOG_ROOT)
+    .filter((name) => /^\d{4}-\d{2}-\d{2}$/.test(name))
+    .map((name) => join(LOG_ROOT, name))
+    .filter((path) => statSafe(path)?.isDirectory())
+    .sort();
+  if (dirs.length === 0) return null;
+  const latestDir = dirs[dirs.length - 1];
+  const files = readdirSync(latestDir)
+    .filter((name) => name.endsWith(".jsonl"))
+    .map((name) => join(latestDir, name))
+    .map((path) => ({ path, mtime: statSafe(path)?.mtimeMs || 0 }))
+    .sort((a, b) => b.mtime - a.mtime);
+  return files[0]?.path || null;
+}
+
+const argIndex = process.argv.indexOf("--file");
+const filePath = argIndex !== -1 ? process.argv[argIndex + 1] : findLatestFile();
+
+if (!filePath) {
+  console.error("✗ No log file found");
+  process.exit(1);
+}
+
+const statusCounts = new Map();
+const failures = [];
+let totalResponses = 0;
+let totalRequests = 0;
+
+try {
+  const data = readFileSync(filePath, "utf8");
+  const lines = data.split("\n").filter(Boolean);
+  for (const line of lines) {
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (entry.type === "network.request") {
+      totalRequests += 1;
+    } else if (entry.type === "network.response") {
+      totalResponses += 1;
+      const status = String(entry.status ?? "unknown");
+      statusCounts.set(status, (statusCounts.get(status) || 0) + 1);
+    } else if (entry.type === "network.failure") {
+      failures.push({
+        requestId: entry.requestId,
+        errorText: entry.errorText,
+      });
+    }
+  }
+} catch (e) {
+  console.error("✗ summary failed:", e.message);
+  process.exit(1);
+}
+
+console.log(`file: ${filePath}`);
+console.log(`requests: ${totalRequests}`);
+console.log(`responses: ${totalResponses}`);
+
+const statuses = Array.from(statusCounts.entries()).sort(
+  (a, b) => Number(a[0]) - Number(b[0]),
+);
+for (const [status, count] of statuses) {
+  console.log(`status ${status}: ${count}`);
+}
+
+if (failures.length > 0) {
+  console.log("failures:");
+  for (const failure of failures.slice(0, 10)) {
+    console.log(`- ${failure.errorText || "unknown"} (${failure.requestId})`);
+  }
+  if (failures.length > 10) {
+    console.log(`- ... ${failures.length - 10} more`);
+  }
+}

--- a/agents/skills/web-browser/scripts/package-lock.json
+++ b/agents/skills/web-browser/scripts/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "scripts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/agents/skills/web-browser/scripts/package.json
+++ b/agents/skills/web-browser/scripts/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "dependencies": {
+    "ws": "^8.18.0"
+  }
+}

--- a/agents/skills/web-browser/scripts/pick.js
+++ b/agents/skills/web-browser/scripts/pick.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+import { connect } from "./cdp.js";
+
+const DEBUG = process.env.DEBUG === "1";
+const log = DEBUG ? (...args) => console.error("[debug]", ...args) : () => {};
+
+const message = process.argv.slice(2).join(" ");
+if (!message) {
+  console.log("Usage: pick.js 'message'");
+  console.log("\nExample:");
+  console.log('  pick.js "Click the submit button"');
+  process.exit(1);
+}
+
+// Global timeout - 5 minutes for interactive picking
+const globalTimeout = setTimeout(() => {
+  console.error("✗ Global timeout exceeded (5m)");
+  process.exit(1);
+}, 300000);
+
+const PICK_SCRIPT = `(message) => {
+  if (!message) throw new Error("pick() requires a message parameter");
+  return new Promise((resolve) => {
+    const selections = [];
+    const selectedElements = new Set();
+
+    const overlay = document.createElement("div");
+    overlay.style.cssText = "position:fixed;top:0;left:0;width:100%;height:100%;z-index:2147483647;pointer-events:none";
+
+    const highlight = document.createElement("div");
+    highlight.style.cssText = "position:absolute;border:2px solid #3b82f6;background:rgba(59,130,246,0.1);transition:all 0.1s";
+    overlay.appendChild(highlight);
+
+    const banner = document.createElement("div");
+    banner.style.cssText = "position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:#1f2937;color:white;padding:12px 24px;border-radius:8px;font:14px sans-serif;box-shadow:0 4px 12px rgba(0,0,0,0.3);pointer-events:auto;z-index:2147483647";
+
+    const updateBanner = () => {
+      banner.textContent = message + " (" + selections.length + " selected, Cmd/Ctrl+click to add, Enter to finish, ESC to cancel)";
+    };
+    updateBanner();
+
+    document.body.append(banner, overlay);
+
+    const cleanup = () => {
+      document.removeEventListener("mousemove", onMove, true);
+      document.removeEventListener("click", onClick, true);
+      document.removeEventListener("keydown", onKey, true);
+      overlay.remove();
+      banner.remove();
+      selectedElements.forEach((el) => { el.style.outline = ""; });
+    };
+
+    const onMove = (e) => {
+      const el = document.elementFromPoint(e.clientX, e.clientY);
+      if (!el || overlay.contains(el) || banner.contains(el)) return;
+      const r = el.getBoundingClientRect();
+      highlight.style.cssText = "position:absolute;border:2px solid #3b82f6;background:rgba(59,130,246,0.1);top:" + r.top + "px;left:" + r.left + "px;width:" + r.width + "px;height:" + r.height + "px";
+    };
+
+    const buildElementInfo = (el) => {
+      const parents = [];
+      let current = el.parentElement;
+      while (current && current !== document.body) {
+        const parentInfo = current.tagName.toLowerCase();
+        const id = current.id ? "#" + current.id : "";
+        const cls = current.className ? "." + current.className.trim().split(/\\s+/).join(".") : "";
+        parents.push(parentInfo + id + cls);
+        current = current.parentElement;
+      }
+      return {
+        tag: el.tagName.toLowerCase(),
+        id: el.id || null,
+        class: el.className || null,
+        text: (el.textContent || "").trim().slice(0, 200) || null,
+        html: el.outerHTML.slice(0, 500),
+        parents: parents.join(" > "),
+      };
+    };
+
+    const onClick = (e) => {
+      if (banner.contains(e.target)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const el = document.elementFromPoint(e.clientX, e.clientY);
+      if (!el || overlay.contains(el) || banner.contains(el)) return;
+
+      if (e.metaKey || e.ctrlKey) {
+        if (!selectedElements.has(el)) {
+          selectedElements.add(el);
+          el.style.outline = "3px solid #10b981";
+          selections.push(buildElementInfo(el));
+          updateBanner();
+        }
+      } else {
+        cleanup();
+        const info = buildElementInfo(el);
+        resolve(selections.length > 0 ? selections : info);
+      }
+    };
+
+    const onKey = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        cleanup();
+        resolve(null);
+      } else if (e.key === "Enter" && selections.length > 0) {
+        e.preventDefault();
+        cleanup();
+        resolve(selections);
+      }
+    };
+
+    document.addEventListener("mousemove", onMove, true);
+    document.addEventListener("click", onClick, true);
+    document.addEventListener("keydown", onKey, true);
+  });
+}`;
+
+try {
+  log("connecting...");
+  const cdp = await connect(5000);
+
+  log("getting pages...");
+  const pages = await cdp.getPages();
+  const page = pages.at(-1);
+
+  if (!page) {
+    console.error("✗ No active tab found");
+    process.exit(1);
+  }
+
+  log("attaching to page...");
+  const sessionId = await cdp.attachToPage(page.targetId);
+
+  log("waiting for user pick...");
+  const expression = `(${PICK_SCRIPT})(${JSON.stringify(message)})`;
+  const result = await cdp.evaluate(sessionId, expression, 300000);
+
+  log("formatting result...");
+  if (Array.isArray(result)) {
+    for (let i = 0; i < result.length; i++) {
+      if (i > 0) console.log("");
+      for (const [key, value] of Object.entries(result[i])) {
+        console.log(`${key}: ${value}`);
+      }
+    }
+  } else if (typeof result === "object" && result !== null) {
+    for (const [key, value] of Object.entries(result)) {
+      console.log(`${key}: ${value}`);
+    }
+  } else {
+    console.log(result);
+  }
+
+  log("closing...");
+  cdp.close();
+  log("done");
+} catch (e) {
+  console.error("✗", e.message);
+  process.exit(1);
+} finally {
+  clearTimeout(globalTimeout);
+  setTimeout(() => process.exit(0), 100);
+}

--- a/agents/skills/web-browser/scripts/screenshot.js
+++ b/agents/skills/web-browser/scripts/screenshot.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFileSync } from "node:fs";
+import { connect } from "./cdp.js";
+
+const DEBUG = process.env.DEBUG === "1";
+const log = DEBUG ? (...args) => console.error("[debug]", ...args) : () => {};
+
+// Global timeout
+const globalTimeout = setTimeout(() => {
+  console.error("✗ Global timeout exceeded (15s)");
+  process.exit(1);
+}, 15000);
+
+try {
+  log("connecting...");
+  const cdp = await connect(5000);
+
+  log("getting pages...");
+  const pages = await cdp.getPages();
+  const page = pages.at(-1);
+
+  if (!page) {
+    console.error("✗ No active tab found");
+    process.exit(1);
+  }
+
+  log("attaching to page...");
+  const sessionId = await cdp.attachToPage(page.targetId);
+
+  log("taking screenshot...");
+  const data = await cdp.screenshot(sessionId);
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `screenshot-${timestamp}.png`;
+  const filepath = join(tmpdir(), filename);
+
+  writeFileSync(filepath, data);
+  console.log(filepath);
+
+  log("closing...");
+  cdp.close();
+  log("done");
+} catch (e) {
+  console.error("✗", e.message);
+  process.exit(1);
+} finally {
+  clearTimeout(globalTimeout);
+  setTimeout(() => process.exit(0), 100);
+}

--- a/agents/skills/web-browser/scripts/start.js
+++ b/agents/skills/web-browser/scripts/start.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import { spawn, execSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const args = new Set(process.argv.slice(2));
+const useProfile = args.has("--profile");
+
+const unknownArgs = [...args].filter((arg) => arg !== "--profile");
+if (unknownArgs.length > 0) {
+  console.log("Usage: start.js [--profile]");
+  console.log("\nOptions:");
+  console.log(
+    "  --profile  Copy your default Chrome profile (cookies, logins)",
+  );
+  console.log("\nExamples:");
+  console.log("  start.js            # Start with fresh profile");
+  console.log("  start.js --profile  # Start with your Chrome profile");
+  process.exit(1);
+}
+
+async function isDebugEndpointUp() {
+  try {
+    const response = await fetch("http://localhost:9222/json/version");
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+// If something is already listening on :9222, reuse it instead of killing Chrome.
+if (await isDebugEndpointUp()) {
+  console.log("✓ Chrome already running on :9222 (reusing existing instance)");
+  process.exit(0);
+}
+
+// Setup profile directory
+execSync("mkdir -p ~/.cache/scraping", { stdio: "ignore" });
+
+if (useProfile) {
+  // Sync profile with rsync (much faster on subsequent runs)
+  execSync(
+    `rsync -a --delete --exclude 'Singleton*' --exclude 'DevToolsActivePort*' "${process.env["HOME"]}/Library/Application Support/Google/Chrome/" ~/.cache/scraping/`,
+    { stdio: "pipe" },
+  );
+}
+
+// Remove stale singleton/debug artifacts that can make Chrome forward to an
+// already running browser instance (which drops our debug flags).
+for (const staleFile of [
+  "SingletonCookie",
+  "SingletonLock",
+  "SingletonSocket",
+  "DevToolsActivePort",
+  "DevToolsActivePort.lock",
+]) {
+  try {
+    rmSync(`${process.env["HOME"]}/.cache/scraping/${staleFile}`, { force: true });
+  } catch {
+    // ignore
+  }
+}
+
+function resolveChromeBinary() {
+  if (process.env.BROWSER_BIN && existsSync(process.env.BROWSER_BIN)) {
+    return process.env.BROWSER_BIN;
+  }
+
+  const candidates = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+  ];
+
+  return candidates.find((path) => existsSync(path)) || null;
+}
+
+const chromeBinary = resolveChromeBinary();
+
+if (!chromeBinary) {
+  console.error("✗ Could not find Chrome/Chromium binary");
+  console.error("  Set BROWSER_BIN=/path/to/chrome and retry");
+  process.exit(1);
+}
+
+const chromeArgs = [
+  "--remote-debugging-port=9222",
+  `--user-data-dir=${process.env["HOME"]}/.cache/scraping`,
+  "--profile-directory=Default",
+  "--disable-search-engine-choice-screen",
+  "--no-first-run",
+  "--disable-features=ProfilePicker",
+];
+
+const chromeProc = spawn(chromeBinary, chromeArgs, { detached: true, stdio: "ignore" });
+chromeProc.unref();
+
+// Wait for Chrome to be ready by checking the debugging endpoint
+let connected = false;
+for (let i = 0; i < 30; i++) {
+  try {
+    const response = await fetch("http://localhost:9222/json/version");
+    if (response.ok) {
+      connected = true;
+      break;
+    }
+  } catch {
+    // ignore; wait below
+  }
+  await new Promise((r) => setTimeout(r, 500));
+}
+
+if (!connected) {
+  console.error("✗ Failed to connect to Chrome on :9222");
+  console.error(`  Attempted binary: ${chromeBinary}`);
+  process.exit(1);
+}
+
+// Start background watcher for logs/network (detached)
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const watcherPath = join(scriptDir, "watch.js");
+spawn(process.execPath, [watcherPath], { detached: true, stdio: "ignore" }).unref();
+
+console.log(
+  `✓ Chrome started on :9222${useProfile ? " with your profile" : ""}`,
+);

--- a/agents/skills/web-browser/scripts/watch.js
+++ b/agents/skills/web-browser/scripts/watch.js
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+import { createWriteStream, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { connect } from "./cdp.js";
+
+const LOG_ROOT = join(homedir(), ".cache/agent-web/logs");
+const PID_FILE = join(LOG_ROOT, ".pid");
+
+function ensureDir(dir) {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getDateDir() {
+  const now = new Date();
+  const yyyy = String(now.getFullYear());
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return join(LOG_ROOT, `${yyyy}-${mm}-${dd}`);
+}
+
+function safeFileName(value) {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function compactStack(stackTrace) {
+  if (!stackTrace || !Array.isArray(stackTrace.callFrames)) return null;
+  return stackTrace.callFrames.slice(0, 8).map((frame) => ({
+    functionName: frame.functionName || null,
+    url: frame.url || null,
+    lineNumber: frame.lineNumber,
+    columnNumber: frame.columnNumber,
+  }));
+}
+
+function serializeRemoteObject(obj) {
+  if (!obj || typeof obj !== "object") return obj;
+  const value =
+    Object.prototype.hasOwnProperty.call(obj, "value")
+      ? obj.value
+      : obj.unserializableValue || obj.description || null;
+  return {
+    type: obj.type || null,
+    subtype: obj.subtype || null,
+    value,
+    description: obj.description || null,
+  };
+}
+
+ensureDir(LOG_ROOT);
+
+if (existsSync(PID_FILE)) {
+  try {
+    const existing = Number(readFileSync(PID_FILE, "utf8").trim());
+    if (existing && isProcessAlive(existing)) {
+      console.log("✓ watch already running");
+      process.exit(0);
+    }
+  } catch {
+    // Ignore and overwrite stale pid.
+  }
+}
+
+writeFileSync(PID_FILE, String(process.pid));
+
+const dateDir = getDateDir();
+ensureDir(dateDir);
+
+const targetState = new Map();
+const sessionToTarget = new Map();
+
+function getStreamForTarget(targetId) {
+  const state = targetState.get(targetId);
+  if (state?.stream) return state.stream;
+  const filename = `${safeFileName(targetId)}.jsonl`;
+  const filepath = join(dateDir, filename);
+  const stream = createWriteStream(filepath, { flags: "a" });
+  if (state) state.stream = stream;
+  return stream;
+}
+
+function writeLog(targetId, payload) {
+  const stream = getStreamForTarget(targetId);
+  const record = {
+    ts: new Date().toISOString(),
+    targetId,
+    ...payload,
+  };
+  stream.write(`${JSON.stringify(record)}\n`);
+}
+
+async function enableSession(cdp, sessionId) {
+  await cdp.send("Runtime.enable", {}, sessionId);
+  await cdp.send("Log.enable", {}, sessionId);
+  await cdp.send("Network.enable", {}, sessionId);
+  await cdp.send("Page.enable", {}, sessionId);
+}
+
+async function attachToTarget(cdp, targetInfo) {
+  if (targetInfo.type !== "page") return;
+  if (targetState.has(targetInfo.targetId)) return;
+
+  const { sessionId } = await cdp.send("Target.attachToTarget", {
+    targetId: targetInfo.targetId,
+    flatten: true,
+  });
+
+  targetState.set(targetInfo.targetId, {
+    sessionId,
+    url: targetInfo.url || null,
+    title: targetInfo.title || null,
+    stream: null,
+  });
+  sessionToTarget.set(sessionId, targetInfo.targetId);
+
+  await enableSession(cdp, sessionId);
+  writeLog(targetInfo.targetId, {
+    type: "target.attached",
+    url: targetInfo.url || null,
+    title: targetInfo.title || null,
+  });
+}
+
+async function main() {
+  const cdp = await connect(5000);
+
+  cdp.on("Target.targetCreated", async (params) => {
+    try {
+      await attachToTarget(cdp, params.targetInfo);
+    } catch (e) {
+      console.error("watch: attach error:", e.message);
+    }
+  });
+
+  cdp.on("Target.targetDestroyed", (params) => {
+    const targetId = params.targetId;
+    const state = targetState.get(targetId);
+    if (state?.stream) state.stream.end();
+    targetState.delete(targetId);
+    if (state?.sessionId) sessionToTarget.delete(state.sessionId);
+  });
+
+  cdp.on("Target.targetInfoChanged", (params) => {
+    const info = params.targetInfo;
+    const state = targetState.get(info.targetId);
+    if (state) {
+      state.url = info.url || state.url;
+      state.title = info.title || state.title;
+      writeLog(info.targetId, {
+        type: "target.info",
+        url: info.url || null,
+        title: info.title || null,
+      });
+    }
+  });
+
+  cdp.on("Runtime.consoleAPICalled", (params, sessionId) => {
+    const targetId = sessionToTarget.get(sessionId);
+    if (!targetId) return;
+    writeLog(targetId, {
+      type: "console",
+      level: params.type || null,
+      args: (params.args || []).map(serializeRemoteObject),
+      stack: compactStack(params.stackTrace),
+    });
+  });
+
+  cdp.on("Runtime.exceptionThrown", (params, sessionId) => {
+    const targetId = sessionToTarget.get(sessionId);
+    if (!targetId) return;
+    const details = params.exceptionDetails || {};
+    writeLog(targetId, {
+      type: "exception",
+      text: details.text || null,
+      description: details.exception?.description || null,
+      lineNumber: details.lineNumber,
+      columnNumber: details.columnNumber,
+      url: details.url || null,
+      stack: compactStack(details.stackTrace),
+    });
+  });
+
+  cdp.on("Log.entryAdded", (params, sessionId) => {
+    const targetId = sessionToTarget.get(sessionId);
+    if (!targetId) return;
+    const entry = params.entry || {};
+    writeLog(targetId, {
+      type: "log",
+      level: entry.level || null,
+      source: entry.source || null,
+      text: entry.text || null,
+      url: entry.url || null,
+      lineNumber: entry.lineNumber ?? null,
+    });
+  });
+
+  cdp.on("Network.requestWillBeSent", (params, sessionId) => {
+    const targetId = sessionToTarget.get(sessionId);
+    if (!targetId) return;
+    const request = params.request || {};
+    writeLog(targetId, {
+      type: "network.request",
+      requestId: params.requestId,
+      method: request.method || null,
+      url: request.url || null,
+      documentURL: params.documentURL || null,
+      initiator: params.initiator?.type || null,
+      hasPostData: !!request.hasPostData,
+    });
+  });
+
+  cdp.on("Network.responseReceived", (params, sessionId) => {
+    const targetId = sessionToTarget.get(sessionId);
+    if (!targetId) return;
+    const response = params.response || {};
+    writeLog(targetId, {
+      type: "network.response",
+      requestId: params.requestId,
+      url: response.url || null,
+      status: response.status,
+      statusText: response.statusText || null,
+      mimeType: response.mimeType || null,
+      fromDiskCache: !!response.fromDiskCache,
+      fromServiceWorker: !!response.fromServiceWorker,
+    });
+  });
+
+  cdp.on("Network.loadingFailed", (params, sessionId) => {
+    const targetId = sessionToTarget.get(sessionId);
+    if (!targetId) return;
+    writeLog(targetId, {
+      type: "network.failure",
+      requestId: params.requestId,
+      errorText: params.errorText || null,
+      canceled: !!params.canceled,
+    });
+  });
+
+  await cdp.send("Target.setDiscoverTargets", { discover: true });
+
+  const pages = await cdp.getPages();
+  for (const page of pages) {
+    await attachToTarget(cdp, page);
+  }
+
+  console.log("✓ watch started");
+}
+
+try {
+  await main();
+} catch (e) {
+  console.error("✗ watch failed:", e.message);
+  process.exit(1);
+}

--- a/agents/skills/writing-plans/SKILL.md
+++ b/agents/skills/writing-plans/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: writing-plans
+description: Writes detailed implementation plans with bite-sized tasks, exact file paths, complete code, and TDD steps. Use when a design or spec has been approved and is ready to be turned into an implementation plan. Triggers on "write a plan for this", "create an implementation plan", "how do we build this", "plan out the implementation", or after brainstorming/design is complete. Always write plans before starting implementation — never skip to code.
+---
+
+# Writing Plans
+
+**Announce:** "I'm using the writing-plans skill to create the implementation plan."
+
+## Principles
+
+Write for an engineer who is **skilled but has zero context** on your codebase, tooling, or domain. Assume they:
+- Don't know file locations or naming conventions
+- Won't make good test design decisions without guidance
+- Will implement tasks out of order if the plan allows it
+- Will add extra features if the spec leaves room
+
+**DRY. YAGNI. TDD. Frequent commits.**
+
+## Plan Format
+
+Save to: `docs/plans/YYYY-MM-DD-<feature-name>.md`
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For implementors:** Work through tasks using the executing-plans or subagent-driven-development skill.
+
+**Goal:** [One sentence]  
+**Architecture:** [2–3 sentences]  
+**Tech stack:** [Key technologies]
+
+---
+
+### Task 1: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/new-file.py`
+- Modify: `exact/path/to/existing.py`
+- Test: `tests/exact/path/to/test_file.py`
+
+- [ ] **Step 1: Write the failing test**
+  ```python
+  def test_specific_behavior():
+      result = function_under_test(input_value)
+      assert result == expected_value
+  ```
+
+- [ ] **Step 2: Run test — confirm it fails**
+  ```
+  pytest tests/exact/path/to/test_file.py::test_specific_behavior -v
+  ```
+  Expected: FAIL — `function_under_test` not defined
+
+- [ ] **Step 3: Write minimal implementation**
+  ```python
+  def function_under_test(input_value):
+      return expected_value
+  ```
+
+- [ ] **Step 4: Run test — confirm it passes**
+- [ ] **Step 5: Commit**
+  ```
+  git commit -m "feat: add function_under_test"
+  ```
+```
+
+## Required in Every Task
+
+- **Exact file paths** — no "put it somewhere in the models directory"
+- **Complete code** — no "similar to Task 3", no TBD, no "add appropriate error handling"
+- **Working test code** — not "write tests for the above"
+- **Run commands** — exact commands the implementor should run to verify
+- **Commit message** — what to commit after the task
+
+## Forbidden Patterns (These Make a Plan Fail)
+
+- `"TBD"`, `"TODO"`, `"implement later"`, `"fill in details"`
+- `"Add appropriate error handling"` without showing what the handler looks like
+- `"Write tests for the above"` without actual test code
+- `"Similar to Task N"` — repeat the code; tasks may be done out of order
+- Steps that say what to do without showing how
+
+## After Writing the Plan
+
+Self-review checklist:
+- [ ] Every requirement in the spec maps to at least one task
+- [ ] No placeholders anywhere
+- [ ] Every task has test code, implementation code, and a run command
+- [ ] Tasks are ordered so each one can be done without needing a later task
+- [ ] Total task count is realistic for the scope (2–5 min per task is ideal)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -31,6 +31,7 @@ function doIt() {
     excluded=(
         ".git"
         ".claude"
+        "agents"
         "bootstrap.sh"
         "CLAUDE.md"
         "README.md"
@@ -80,14 +81,20 @@ function doIt() {
         done
     fi
 
-    # Symlink skills from ~/.agent-stuff into ~/.claude/skills/
-    if [ -d "$HOME/.agent-stuff/skills" ]; then
+    # Agent skills live in agents/skills and are shared by Claude Code and the
+    # Pi coding agent. Claude discovers them via per-skill symlinks in
+    # ~/.claude/skills/; Pi discovers them via a single ~/.pi/agent/skills link.
+    if [ -d "agents/skills" ]; then
         mkdir -p "$HOME/.claude/skills"
-        for skill_dir in "$HOME/.agent-stuff/skills"/*/; do
+        for skill_dir in "$PWD/agents/skills"/*/; do
             skill_name=$(basename "$skill_dir")
-            ln -sf "$skill_dir" "$HOME/.claude/skills/$skill_name"
+            ln -sfn "$skill_dir" "$HOME/.claude/skills/$skill_name"
             echo "Linked skill: $skill_dir -> $HOME/.claude/skills/$skill_name"
         done
+
+        mkdir -p "$HOME/.pi/agent"
+        ln -sfn "$PWD/agents/skills" "$HOME/.pi/agent/skills"
+        echo "Linked skills: $PWD/agents/skills -> $HOME/.pi/agent/skills"
     fi
 
     if [ -f ".claude/settings.local.json" ]; then

--- a/doctor.sh
+++ b/doctor.sh
@@ -211,6 +211,30 @@ else
     fail "Claude settings" "missing; run ./bootstrap.sh"
 fi
 
+section "Coding agents"
+check_tool "Claude Code" claude
+check_tool "Pi" pi
+# Skills are shared by both agents; bootstrap links them per-agent from
+# agents/skills — per-skill into ~/.claude/skills/, one dir into ~/.pi/agent.
+if [ -d "$DOTFILES/agents/skills" ]; then
+    total=0; linked=0
+    for skill_dir in "$DOTFILES"/agents/skills/*/; do
+        [ -d "$skill_dir" ] || continue
+        total=$((total + 1))
+        case "$(readlink "$HOME/.claude/skills/$(basename "$skill_dir")" 2>/dev/null)" in
+            "$DOTFILES"/*) linked=$((linked + 1)) ;;
+        esac
+    done
+    if [ "$total" -gt 0 ] && [ "$linked" -eq "$total" ]; then
+        pass "Claude skills linked" "$linked/$total from agents/skills"
+    else
+        warn "Claude skills linked" "$linked/$total linked; run ./bootstrap.sh"
+    fi
+    check_repo_link "Pi skills" "$HOME/.pi/agent/skills"
+else
+    warn "Agent skills" "agents/skills missing from repo"
+fi
+
 section "Shell & environment"
 if [ "$CI" -eq 1 ]; then
     note "Default login shell" "skipped with --ci"
@@ -276,26 +300,6 @@ check_optional_tool "prettier" prettier
 if [ "$CI" -eq 1 ]; then
     note "Machine-only checks" "skipped with --ci"
 else
-    # Agent skills live in agents/skills and are linked out to both Claude Code
-    # (per-skill symlinks) and Pi (one directory symlink) by bootstrap.sh.
-    if [ -d "$DOTFILES/agents/skills" ]; then
-        total=0; linked=0
-        for skill_dir in "$DOTFILES"/agents/skills/*/; do
-            [ -d "$skill_dir" ] || continue
-            total=$((total + 1))
-            case "$(readlink "$HOME/.claude/skills/$(basename "$skill_dir")" 2>/dev/null)" in
-                "$DOTFILES"/*) linked=$((linked + 1)) ;;
-            esac
-        done
-        if [ "$total" -gt 0 ] && [ "$linked" -eq "$total" ]; then
-            pass "Claude skills linked" "$linked/$total from agents/skills"
-        else
-            warn "Claude skills linked" "$linked/$total linked; run ./bootstrap.sh"
-        fi
-        check_repo_link "pi skills" "$HOME/.pi/agent/skills"
-    else
-        warn "Agent skills" "agents/skills missing from repo"
-    fi
     if [ "$(uname -s)" = "Darwin" ]; then
         if find "$HOME/Library/Fonts" /Library/Fonts -iname '*Inconsolata*Nerd*' -print 2>/dev/null | grep -q .; then
             pass "Inconsolata Nerd Font" "installed"

--- a/doctor.sh
+++ b/doctor.sh
@@ -276,7 +276,26 @@ check_optional_tool "prettier" prettier
 if [ "$CI" -eq 1 ]; then
     note "Machine-only checks" "skipped with --ci"
 else
-    if [ -d "$HOME/.agent-stuff/skills" ]; then pass "agent-stuff skills" "$HOME/.agent-stuff/skills"; else warn "agent-stuff skills" "clone agent-stuff into ~/.agent-stuff"; fi
+    # Agent skills live in agents/skills and are linked out to both Claude Code
+    # (per-skill symlinks) and Pi (one directory symlink) by bootstrap.sh.
+    if [ -d "$DOTFILES/agents/skills" ]; then
+        total=0; linked=0
+        for skill_dir in "$DOTFILES"/agents/skills/*/; do
+            [ -d "$skill_dir" ] || continue
+            total=$((total + 1))
+            case "$(readlink "$HOME/.claude/skills/$(basename "$skill_dir")" 2>/dev/null)" in
+                "$DOTFILES"/*) linked=$((linked + 1)) ;;
+            esac
+        done
+        if [ "$total" -gt 0 ] && [ "$linked" -eq "$total" ]; then
+            pass "Claude skills linked" "$linked/$total from agents/skills"
+        else
+            warn "Claude skills linked" "$linked/$total linked; run ./bootstrap.sh"
+        fi
+        check_repo_link "pi skills" "$HOME/.pi/agent/skills"
+    else
+        warn "Agent skills" "agents/skills missing from repo"
+    fi
     if [ "$(uname -s)" = "Darwin" ]; then
         if find "$HOME/Library/Fonts" /Library/Fonts -iname '*Inconsolata*Nerd*' -print 2>/dev/null | grep -q .; then
             pass "Inconsolata Nerd Font" "installed"

--- a/setup.sh
+++ b/setup.sh
@@ -225,6 +225,31 @@ setup_python_tools() {
     uv tool install --python 3.14 ty
 }
 
+# ---------------------------------------------------------------------------
+# Coding agents (Claude Code, Pi)
+# ---------------------------------------------------------------------------
+
+setup_agents() {
+    # Claude Code: official native installer, drops `claude` into ~/.local/bin.
+    if have claude; then
+        skip "Claude Code already installed"
+    else
+        info "Installing Claude Code"
+        curl -fsSL https://claude.ai/install.sh | bash || warn "Claude Code install failed (continuing)"
+    fi
+
+    # Pi coding agent: npm-distributed, exposes the `pi` command. Needs node/npm,
+    # which the macOS and Linux paths above install.
+    if have pi; then
+        skip "Pi coding agent already installed"
+    elif have npm; then
+        info "Installing the Pi coding agent"
+        npm install -g --ignore-scripts @earendil-works/pi-coding-agent || warn "Pi install failed (continuing)"
+    else
+        warn "npm unavailable; cannot install the Pi coding agent"
+    fi
+}
+
 main() {
     case "$(uname -s)" in
         Darwin) info "Detected macOS"; setup_macos ;;
@@ -233,6 +258,7 @@ main() {
     esac
 
     setup_python_tools
+    setup_agents
 
     echo
     info "Done. Tools installed."

--- a/test/doctor.sh
+++ b/test/doctor.sh
@@ -50,7 +50,7 @@ esac
 exit 0
 EOF
 chmod +x "$fake_bin/tool"
-for command_name in nvim tmux zsh git fzf rg fd bat eza btm starship zoxide uv fnm gpg diff-so-fancy node npm markdownlint cargo rustc python3 ruff ty pip reattach-to-user-namespace brew; do
+for command_name in nvim tmux zsh git fzf rg fd bat eza btm starship zoxide uv fnm gpg diff-so-fancy node npm markdownlint cargo rustc python3 ruff ty pip reattach-to-user-namespace brew claude pi; do
     ln -s tool "$fake_bin/$command_name"
 done
 
@@ -62,6 +62,11 @@ for hook in "$ROOT"/.claude/hooks/*.sh; do
     ln -s "$hook" "$healthy_home/.claude/hooks/$(basename "$hook")"
 done
 echo '{}' > "$healthy_home/.claude/settings.json"
+mkdir -p "$healthy_home/.claude/skills"
+for skill_dir in "$ROOT"/agents/skills/*/; do
+    ln -s "$skill_dir" "$healthy_home/.claude/skills/$(basename "$skill_dir")"
+done
+ln -s "$ROOT/agents/skills" "$healthy_home/.pi/agent/skills"
 
 env_path="$fake_bin:/usr/bin:/bin"
 set +e

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -52,6 +52,8 @@ checks=(
     "npm|npm --version"
     "diff-so-fancy|command -v diff-so-fancy"
     "markdownlint|markdownlint --version"
+    "Claude Code|claude --version"
+    "Pi|pi --version"
 )
 
 SOCK="verify"


### PR DESCRIPTION
Skills lived in a separate `~/.agent-stuff` repo that `bootstrap.sh` and `doctor.sh` already depended on but never cloned, so a fresh machine silently ended up with no skills. It also split agent configuration across two repos for no real benefit.

Vendor the skills under a new tool-neutral `agents/skills/` directory and rewire `bootstrap.sh` to link them to both consumers: per-skill symlinks into `~/.claude/skills/` for Claude Code and a single `~/.pi/agent/skills` link for Pi. Exclude `agents/` from the generic link loop so its contents are not mirrored into `$HOME`, and use `ln -sfn` so re-runs repoint existing links instead of nesting inside them.

Update `doctor.sh` to verify the in-repo links, ignore `node_modules/` (pulled in by the `google-workspace` skill), and refresh the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)