### PR TITLE
Reduce Claude Code permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,16 @@
 {
   "model": "sonnet",
   "permissions": {
+    "allow": [
+      "Bash(bundle exec rspec)",
+      "Bash(bundle exec rspec:*)",
+      "Bash(uv run pytest)",
+      "Bash(uv run pytest:*)",
+      "Bash(uv run pyright)",
+      "Bash(uv run pyright:*)",
+      "Bash(uv run black --check)",
+      "Bash(uv run black --check:*)"
+    ],
     "ask": [
       "Bash(gh pr comment)",
       "Bash(gh pr comment:*)",
@@ -47,7 +57,7 @@
           {
             "type": "command",
             "if": "Bash(gh api:*)",
-            "command": "jq -r '.tool_input.command' | grep -qE 'gh api[^|;&]*(comments|reviews)' && printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"gh api comment/review endpoint — confirm to proceed\"}}' || true"
+            "command": "cmd=$(jq -r '.tool_input.command'); echo \"$cmd\" | grep -qE 'gh api[^|;&]*(comments|reviews)' && echo \"$cmd\" | grep -qE '(-X|--method)[ =]+(POST|PATCH|PUT|DELETE)|(^| )(-f|-F|--field|--raw-field|--input)[ =]' && printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"Mutating gh api comment/review call — confirm to proceed\"}}' || true"
           }
         ]
       }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,6 +107,11 @@ def deep_merge(base, local):
     for key, value in local.items():
         if isinstance(value, dict) and isinstance(base.get(key), dict):
             deep_merge(base[key], value)
+        elif isinstance(value, list) and isinstance(base.get(key), list):
+            # Union lists (e.g. permissions.allow) so tracked base entries
+            # and machine-local entries combine instead of local replacing
+            # base wholesale.
+            base[key] = base[key] + [v for v in value if v not in base[key]]
         else:
             base[key] = value
     return base


### PR DESCRIPTION
The `gh api` PreToolUse hook matched the endpoint path, so read-only GETs to `comments`/`reviews` endpoints prompted for confirmation just like writes. Common test and lint commands like `bundle exec rspec` and `uv run pytest` also prompted on every run.

Narrow the hook to fire only when the call actually mutates (has `-X POST/PATCH/PUT/DELETE` or field flags), and add an `allow` list covering those test runners plus read-only checks (`uv run pyright`, `uv run black --check`).

Also fix `deep_merge` in `bootstrap.sh` to union list values instead of replacing them. Previously the `allow` array in `settings.local.json` overwrote any tracked `allow` entries in `settings.json`, so these new rules would have been wiped on the next bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)