### PR TITLE
Add `use-pi-in-pane` skill

### DIFF
--- a/agents/skills/use-pi-in-pane/SKILL.md
+++ b/agents/skills/use-pi-in-pane/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: use-pi-in-pane
+description: Run the `pi` coding agent as a headless subagent (--mode json) inside a visible tmux pane so the user can watch it stream while the agent still captures and verifies its structured output. Use when asked to "run pi in a pane", "let me watch pi work", "run pi where I can see it", or to delegate to pi with a live view. Requires running inside tmux. For a fully headless run with no pane, use use-pi-subagent instead.
+allowed-tools: Bash
+---
+
+# Running pi in a visible tmux pane
+
+This is the [[use-pi-subagent]] flow with a window into it. pi still runs
+**headless in JSON mode** — you drive it, capture the full event stream, and
+verify the result — but it runs in a new tmux pane so the user can watch it
+stream in real time. When pi exits, control returns to you with the JSON log to
+parse, exactly as in the headless skill.
+
+Reach for this when the user wants to *see* pi work. When they just want the
+work done, the plain [[use-pi-subagent]] skill is simpler (no tmux needed).
+
+## How it works
+
+`run-pi-pane.sh` (shipped with this skill) does the plumbing:
+
+- splits a new tmux pane and runs pi there with the canonical headless flags
+  (`--mode json --print --approve --no-session`);
+- the pane shows a readable, prose-only view via `pretty.jq` (text and
+  reasoning as it streams, plus tool markers) — `tee` sits **upstream** of the
+  pretty-printer, so the raw `.jsonl` log is captured in full even if the view
+  hiccups;
+- it **blocks until pi exits**, then prints `KEY=VALUE` lines back to you;
+- the pane stays open afterward so the user can scroll the transcript — they
+  close it themselves with `Ctrl-D`.
+
+The pane is a live view for the human. The `.jsonl` log is the source of truth
+for you.
+
+## Prerequisites
+
+- **Must be inside tmux.** The wrapper needs `$TMUX` to split a pane, and it
+  uses the **user's own tmux server** so the pane is visible to them. Without
+  `$TMUX` it exits with a clear error — fall back to [[use-pi-subagent]].
+- `pi` and `jq` on `PATH`. The wrapper resolves `pi` absolutely from your
+  shell, so fnm's shim works even though the pane's shell may have a leaner
+  `PATH`.
+
+## How to invoke
+
+Write the full task prompt to a file first (a cold `--no-session` run carries no
+context — see [[use-pi-subagent]] for what a good delegation prompt must
+include), then hand it and a unique log path to the wrapper:
+
+```bash
+skill_dir="$AGENT_STUFF/skills/use-pi-in-pane"   # resolve from where SKILL.md lives
+prompt_file="/abs/path/to/task.prompt.md"
+json_log="/abs/path/to/run.jsonl"                 # unique per attempt
+
+bash "$skill_dir/run-pi-pane.sh" \
+  "$prompt_file" \
+  "$json_log" \
+  --model openai-codex/gpt-5.6-terra
+```
+
+Any extra arguments after the log path pass straight through to pi, so
+per-task flags work as usual:
+
+```bash
+bash "$skill_dir/run-pi-pane.sh" "$prompt_file" "$json_log" \
+  --model openai-codex/gpt-5.6-terra --thinking high --no-tools
+```
+
+Resolve the wrapper's absolute path from this skill's directory — don't hardcode
+`~/.agent-stuff/...`.
+
+## Reading the result
+
+The wrapper prints, on its own stdout:
+
+```
+JSON_LOG=/abs/path/to/run.jsonl
+STDERR_LOG=/abs/path/to/run.stderr.log
+PI_EXIT=0            # pi's own exit code
+STATUS=complete      # "complete", or "aborted" if the user closed the pane early
+```
+
+`STATUS=aborted` (wrapper exit 1) means the pane was closed before pi finished —
+the run is incomplete; do not treat its output as done. On `STATUS=complete`,
+parse the log the same way as [[use-pi-subagent]]:
+
+```bash
+# The agent's final answer text
+jq -r 'select(.type=="agent_end") | .messages[-1].content[]?
+       | select(.type=="text") | .text' "$json_log"
+
+# Did it hit an error and intend to retry?
+jq -c 'select(.type=="agent_end") | {willRetry}' "$json_log"
+
+# Total cost of the run
+jq -r 'select(.type=="agent_end") | .messages[-1].usage.cost.total' "$json_log"
+```
+
+For a delegated coding task, **don't trust the final text alone** — verify the
+files pi claims to have changed, run the relevant tests/lint yourself, and check
+`git status` before treating the work as done.
+
+## Pitfalls
+
+- **No `$TMUX`.** The wrapper can't open a pane; it exits 1 with a clear
+  message. Use [[use-pi-subagent]] instead — don't try to force a pane.
+- **The pane lingers on purpose.** After pi exits, the pane drops to a shell so
+  the user can read the transcript. That's intended; the user closes it. You are
+  already unblocked and holding the log — don't wait on the pane.
+- **Give unique log filenames per attempt** so retries don't clobber the audit
+  trail. The wrapper derives `STDERR_LOG`, the exit-code file, and its sentinel
+  from the log path.
+- **Split direction / size.** The wrapper uses a stacked top/bottom split
+  (`-v`). To change it, edit the `tmux split-window` line in `run-pi-pane.sh`.

--- a/agents/skills/use-pi-in-pane/pretty.jq
+++ b/agents/skills/use-pi-in-pane/pretty.jq
@@ -1,0 +1,13 @@
+# pretty.jq — turn pi's --mode json event stream into a readable live
+# view for the tmux pane. Best-effort only: the full-fidelity record is
+# the raw .jsonl log (captured upstream via tee), which the agent parses.
+#
+# Only assistant streaming events carry human-readable text. Everything
+# else (session/turn/agent lifecycle events) is silently dropped so the
+# pane shows prose, not plumbing. Field accesses are defensive so a
+# schema tweak in pi degrades to "less shown", never a jq crash.
+(.assistantMessageEvent // empty) as $e
+| if   ($e.type == "text_delta")                              then ($e.delta // "")
+  elif (($e.type // "") | test("(reasoning|thinking)_delta")) then ($e.delta // "")
+  elif (($e.type // "") | test("^tool"))                      then ("\n> " + ($e.name // $e.toolName // "tool") + "\n")
+  else empty end

--- a/agents/skills/use-pi-in-pane/run-pi-pane.sh
+++ b/agents/skills/use-pi-in-pane/run-pi-pane.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# run-pi-pane.sh
+#
+# Run `pi` as a headless subagent (--mode json) inside a visible tmux
+# pane so the user can watch it work, while the full JSON event stream is
+# still captured to a log the calling agent parses afterward.
+#
+# The pane shows a pretty, prose-only view (pretty.jq); the log gets the
+# raw JSONL. tee sits upstream of jq, so the log is captured even if the
+# pretty view errors. This blocks until pi exits, then returns — the same
+# "kick it off, wait, read the result" contract as the headless
+# use-pi-subagent skill, just visible.
+#
+# Usage:
+#   run-pi-pane.sh <prompt_file> <json_log> [extra pi flags...]
+#
+# Example:
+#   run-pi-pane.sh task.prompt.md run.jsonl \
+#     --model openai-codex/gpt-5.6-terra --thinking high
+#
+# Prints KEY=VALUE lines on stdout (JSON_LOG, STDERR_LOG, PI_EXIT,
+# STATUS) for the caller to read. Exits non-zero if pi could not be run
+# to completion (missing tmux, aborted pane); pi's own exit code is
+# reported via PI_EXIT / the printed STATUS, not this script's status.
+
+set -euo pipefail
+
+PROMPT_FILE="${1:-}"
+JSON_LOG="${2:-}"
+if [ -z "$PROMPT_FILE" ] || [ -z "$JSON_LOG" ]; then
+  echo "run-pi-pane.sh: usage: run-pi-pane.sh <prompt_file> <json_log> [pi flags...]" >&2
+  exit 2
+fi
+shift 2  # remaining args are extra pi flags, passed through verbatim
+
+if [ ! -f "$PROMPT_FILE" ]; then
+  echo "run-pi-pane.sh: prompt file not found: $PROMPT_FILE" >&2
+  exit 2
+fi
+
+if [ -z "${TMUX:-}" ]; then
+  echo "run-pi-pane.sh: not inside a tmux session, cannot open a pane" >&2
+  echo "Run the agent from inside tmux, or use the headless use-pi-subagent skill instead." >&2
+  exit 1
+fi
+
+# Resolve tooling absolutely in the agent's shell (which has the right
+# PATH, e.g. fnm's pi shim). The tmux pane inherits the server's
+# environment, which may not, so we don't rely on its PATH.
+PI_BIN="$(command -v pi || true)"
+if [ -z "$PI_BIN" ]; then
+  echo "run-pi-pane.sh: pi not found on PATH" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRETTY_JQ="$SCRIPT_DIR/pretty.jq"
+
+STDERR_LOG="${JSON_LOG%.jsonl}.stderr.log"
+[ "$STDERR_LOG" = "$JSON_LOG" ] && STDERR_LOG="$JSON_LOG.stderr.log"
+STATUS_FILE="$JSON_LOG.pi-exit"
+SENTINEL="$JSON_LOG.pane-done"
+PANE_SCRIPT="$JSON_LOG.pane.sh"
+rm -f "$STATUS_FILE" "$SENTINEL" "$PANE_SCRIPT"
+
+# Write the pane's work to a real script file rather than cramming it
+# into `bash -c '...'` — the pipeline itself contains single quotes, so
+# any inline-quoting scheme is a foot-gun. The prompt text is read via
+# $(cat ...) inside the pane, so arbitrary prompt content never touches
+# this command line. pi's exit code is taken from the head of the pipe
+# (PIPESTATUS) and recorded before the sentinel is touched, so the waiter
+# below always has a status to report. We then exec a shell so the pane
+# stays open for the user to read/scroll — they close it themselves.
+cat > "$PANE_SCRIPT" <<EOF
+#!/usr/bin/env bash
+"$PI_BIN" --mode json --print --approve --no-session $* "\$(cat '$PROMPT_FILE')" \\
+  2>'$STDERR_LOG' | tee '$JSON_LOG' | jq -rj --unbuffered -f '$PRETTY_JQ'
+st=\${PIPESTATUS[0]}
+printf '%s' "\$st" > '$STATUS_FILE'
+printf '\n\n---- pi finished (exit %s) ---- (Ctrl-D to close this pane)\n' "\$st"
+touch '$SENTINEL'
+exec "\${SHELL:-/bin/sh}"
+EOF
+
+# -v: stacked top/bottom split so a long stream is easy to watch below the
+#     agent. -c: start in the current repo so pi's relative paths and
+#     context-file discovery resolve correctly.
+PANE=$(tmux split-window -v -P -F '#{pane_id}' -c "$PWD" "bash \"$PANE_SCRIPT\"")
+
+# Block until pi finishes (sentinel appears). The dead-pane guard means
+# this can never hang: if the pane exits early — whether it vanishes
+# (remain-on-exit off) or lingers dead (remain-on-exit on) — pane_dead
+# stops being "0" and we stop waiting. Missing sentinel afterward == the
+# run was aborted before pi completed.
+while [ ! -f "$SENTINEL" ]; do
+  dead="$(tmux display-message -p -t "$PANE" '#{pane_dead}' 2>/dev/null || echo gone)"
+  [ "$dead" != "0" ] && break
+  sleep 0.3
+done
+
+aborted=0
+[ -f "$SENTINEL" ] || aborted=1
+
+PI_EXIT=""
+[ -f "$STATUS_FILE" ] && PI_EXIT="$(cat "$STATUS_FILE")"
+rm -f "$SENTINEL" "$PANE_SCRIPT"
+
+echo "JSON_LOG=$JSON_LOG"
+echo "STDERR_LOG=$STDERR_LOG"
+echo "PI_EXIT=$PI_EXIT"
+if [ "$aborted" = 1 ]; then
+  echo "STATUS=aborted"
+  echo "run-pi-pane.sh: pane closed before pi finished; run is incomplete" >&2
+  exit 1
+fi
+echo "STATUS=complete"


### PR DESCRIPTION
The `use-pi-subagent` skill runs pi fully headless in JSON mode: the agent drives it and parses its output, but there is no way to watch it work. When you want to see pi as it runs, the only option was to give up the structured log and drive it interactively yourself.

Add a sibling `use-pi-in-pane` skill that keeps the headless JSON contract but runs pi inside a visible tmux pane. A `run-pi-pane.sh` wrapper splits a new tmux pane, streams a prose-only view via `pretty.jq`, and captures the full raw `.jsonl` with `tee` upstream of the pretty-printer so the log survives even if the view hiccups. It blocks until pi exits, then reports the log paths and exit status back to the caller, just like the headless flow.

The wrapper runs its pane command from a generated script file rather than `bash -c`, since the pipeline itself contains single quotes, and guards on `pane_dead` so it can never hang if the pane closes early or the user has `remain-on-exit on`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)