### PR TITLE
Improve `pi` pane tool output

### DIFF
--- a/agents/skills/use-pi-in-pane/SKILL.md
+++ b/agents/skills/use-pi-in-pane/SKILL.md
@@ -21,10 +21,11 @@ work done, the plain [[use-pi-subagent]] skill is simpler (no tmux needed).
 
 - splits a new tmux pane and runs pi there with the canonical headless flags
   (`--mode json --print --approve --no-session`);
-- the pane shows a readable, prose-only view via `pretty.jq` (text and
-  reasoning as it streams, plus tool markers) — `tee` sits **upstream** of the
-  pretty-printer, so the raw `.jsonl` log is captured in full even if the view
-  hiccups;
+- the pane shows a readable activity stream via `pretty.jq`: text and
+  reasoning as it arrives, plus one concise summary for each tool execution
+  with its name, most useful argument, and any failure — `tee` sits
+  **upstream** of the pretty-printer, so the raw `.jsonl` log is captured in
+  full even if the view hiccups;
 - it **blocks until pi exits**, then prints `KEY=VALUE` lines back to you;
 - the pane stays open afterward so the user can scroll the transcript — they
   close it themselves with `Ctrl-D`.

--- a/agents/skills/use-pi-in-pane/pretty.jq
+++ b/agents/skills/use-pi-in-pane/pretty.jq
@@ -2,12 +2,62 @@
 # view for the tmux pane. Best-effort only: the full-fidelity record is
 # the raw .jsonl log (captured upstream via tee), which the agent parses.
 #
-# Only assistant streaming events carry human-readable text. Everything
-# else (session/turn/agent lifecycle events) is silently dropped so the
-# pane shows prose, not plumbing. Field accesses are defensive so a
-# schema tweak in pi degrades to "less shown", never a jq crash.
-(.assistantMessageEvent // empty) as $e
-| if   ($e.type == "text_delta")                              then ($e.delta // "")
-  elif (($e.type // "") | test("(reasoning|thinking)_delta")) then ($e.delta // "")
-  elif (($e.type // "") | test("^tool"))                      then ("\n> " + ($e.name // $e.toolName // "tool") + "\n")
-  else empty end
+# Assistant deltas carry prose and reasoning. Tool execution events carry
+# the completed tool name and arguments; the earlier toolcall_* deltas are
+# deliberately ignored because they contain partial JSON and would print a
+# marker for every streamed token.
+def clean:
+  tostring
+  | gsub("[[:space:]]+"; " ")
+  | sub("^ +"; "")
+  | sub(" +$"; "");
+
+def clip:
+  clean
+  | if length > 180 then .[0:179] + "…" else . end;
+
+def argument_detail:
+  (.args // {}) as $args
+  | if (($args.command? | type) == "string") then
+      $args.command | clip
+    elif (($args.path? | type) == "string") then
+      ([if $args.offset? != null then "offset \($args.offset)" else empty end,
+        if $args.limit? != null then "limit \($args.limit)" else empty end]
+       | join(", ")) as $range
+      | ($args.path | clip) + (if $range == "" then "" else " (\($range))" end)
+    elif (($args.query? | type) == "string") then
+      $args.query | clip
+    elif (($args.queries? | type) == "array") then
+      $args.queries | join("; ") | clip
+    elif (($args.url? | type) == "string") then
+      $args.url | clip
+    elif (($args.urls? | type) == "array") then
+      $args.urls | join(", ") | clip
+    elif $args == {} then
+      ""
+    else
+      $args | tojson | clip
+    end;
+
+def error_detail:
+  [(.result.content? // [])[]? | select(.type == "text") | .text]
+  | join(" ")
+  | clip;
+
+def tool_line($marker; $name; $detail):
+  $marker + " " + ($name // "tool")
+  + (if $detail == "" then "" else "  " + $detail end)
+  + "\n";
+
+(.assistantMessageEvent // {}) as $event
+| if .type == "tool_execution_start" then
+    tool_line("▸"; .toolName; argument_detail)
+  elif .type == "tool_execution_end" and .isError == true then
+    tool_line("✗"; .toolName; error_detail)
+  elif $event.type == "text_delta" then
+    ($event.delta // "")
+  elif (($event.type // "") | test("(reasoning|thinking)_delta")) then
+    ($event.delta // "")
+  else
+    empty
+  end

--- a/test/pi-pane-pretty.sh
+++ b/test/pi-pane-pretty.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+FILTER="$REPO_ROOT/agents/skills/use-pi-in-pane/pretty.jq"
+
+actual=$(mktemp)
+expected=$(mktemp)
+trap 'rm -f "$actual" "$expected"' EXIT
+
+cat <<'JSONL' | jq -rj -f "$FILTER" > "$actual"
+{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"**Inspecting the formatter**\n\n"}}
+{"type":"message_update","assistantMessageEvent":{"type":"toolcall_start","partial":{"content":[{"type":"toolCall","name":"read","arguments":{}}]}}}
+{"type":"message_update","assistantMessageEvent":{"type":"toolcall_delta","delta":"{\"path\":"}}
+{"type":"message_update","assistantMessageEvent":{"type":"toolcall_end","toolCall":{"name":"read","arguments":{"path":"agents/skills/use-pi-in-pane/pretty.jq"}}}}
+{"type":"tool_execution_start","toolCallId":"read-1","toolName":"read","args":{"path":"agents/skills/use-pi-in-pane/pretty.jq","offset":10,"limit":20}}
+{"type":"tool_execution_start","toolCallId":"bash-1","toolName":"bash","args":{"command":"printf 'one'\nprintf 'two'","timeout":10}}
+{"type":"tool_execution_start","toolCallId":"custom-1","toolName":"custom","args":{"target":"pane","verbose":true}}
+{"type":"tool_execution_end","toolCallId":"bash-1","toolName":"bash","result":{"content":[{"type":"text","text":"permission denied\nmore detail"}]},"isError":true}
+JSONL
+
+cat > "$expected" <<'OUTPUT'
+**Inspecting the formatter**
+
+▸ read  agents/skills/use-pi-in-pane/pretty.jq (offset 10, limit 20)
+▸ bash  printf 'one' printf 'two'
+▸ custom  {"target":"pane","verbose":true}
+✗ bash  permission denied more detail
+OUTPUT
+
+if ! diff -u "$expected" "$actual"; then
+    echo "pi pane formatter output did not match" >&2
+    exit 1
+fi
+
+echo "pi pane formatter output: ok"

--- a/test/run.sh
+++ b/test/run.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 "$REPO_ROOT/test/setup-script-name.sh"
+"$REPO_ROOT/test/pi-pane-pretty.sh"
 
 IMAGE=dotfiles-test
 INTERACTIVE=0


### PR DESCRIPTION
## Problem

The pane formatter treated every streamed tool-call token as a separate tool event. This made the transcript hard to read because partial events omitted tool names and filled the pane with generic markers.

## Output

### Before

> tool
>
> tool
>
> tool

### After

> ▸ read  agents/skills/use-pi-in-pane/pretty.jq
>
> ▸ bash  git status --short

## Solution

Render one concise summary from each actual tool execution, including useful arguments and failures. Add a regression test that ensures partial tool-call events remain silent.
