### PR TITLE
Add `bro` skill for plain-language restatements

### DIFF
--- a/agents/skills/bro/SKILL.md
+++ b/agents/skills/bro/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: bro
+description: "Restate your previous message in plain language — no jargon, no ceremony, just one human explaining something to another. Use when the user says 'bro', 'in plain English', 'say that again simply', 'what does that mean', or otherwise signals the last answer was too dense or too technical."
+---
+
+# Bro
+
+Restate your last message. Stop using jargon and speak coherently. State
+it more simply and concisely, like one human talking to another.
+
+## Rules
+
+- Restate the **same** content. Don't do new work, don't research, don't
+  fix anything, don't add caveats you didn't already give.
+- Lead with the answer or the point. No preamble, no recap of the
+  question.
+- Drop jargon. If a technical term is unavoidable (a file name, a command,
+  a library), keep it and say plainly what it does.
+- Keep it short. A couple of sentences, or a few short bullets if there
+  are genuinely separate points.
+- Don't apologize for the earlier message or explain that you're
+  simplifying. Just say the simpler thing.
+- If the earlier message was already plain, say the same thing shorter
+  rather than padding it out.


### PR DESCRIPTION
Answers sometimes come back denser than they need to be — jargon, headings, hedged caveats — and the usual fix is asking for it again in plain English, which invites a fresh answer rather than a clearer version of the same one.

The `bro` skill pins the behaviour down: restate the previous message and nothing else. No new work, no research, no apology for the first attempt. Lead with the point, drop the jargon, prefer short prose over structure, and shorten rather than pad when the original was already plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)