### PR TITLE
Make the active tmux pane border easier to see

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -79,9 +79,11 @@ set-window-option -g window-status-style "fg=brightblue,bg=default"
 # Active window title colours
 set-window-option -g window-status-current-style "fg=brightred,bg=default"
 
-# Pane border
-set-option -g pane-border-style "fg=black"
-set-option -g pane-active-border-style "fg=brightgreen"
+# Pane border — heavy lines so the active pane is obvious at a glance
+set-option -g pane-border-lines heavy
+set-option -g pane-border-indicators both
+set-option -g pane-border-style "fg=colour238"
+set-option -g pane-active-border-style "fg=brightgreen,bold"
 
 # Message text
 set-option -g message-style "bg=black,fg=brightred"


### PR DESCRIPTION
The pane border used thin single lines with an inactive style of `fg=black`, which blended into the terminal background. Telling which pane had focus meant hunting for the one thin green line.

Switch `pane-border-lines` to `heavy` so the borders are drawn with thicker box-drawing characters, turn on `pane-border-indicators both` to mark the active pane with arrows, and dim inactive borders to `colour238` so they contrast against the bold green active border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)