### PR TITLE
Fix Pi skill health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ The `agents/skills/` directory holds [Agent Skills](https://agentskills.io)
 `~/.claude/skills/` for Claude and points `~/.pi/agent/skills` at the directory
 for Pi.
 
+## Pi extensions
+
+The `agents/extensions/` directory holds global Pi extensions. `bootstrap.sh`
+symlinks each extension into `~/.pi/agent/extensions/`; reload Pi with `/reload`
+after changing one.
+
 ## Checking a machine with `doctor.sh`
 
 Run the doctor after installation to check required tools, linked config,

--- a/agents/extensions/clear.ts
+++ b/agents/extensions/clear.ts
@@ -1,0 +1,10 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function clearExtension(pi: ExtensionAPI) {
+	pi.registerCommand("clear", {
+		description: "Start a new session",
+		handler: async (_args, ctx) => {
+			await ctx.newSession();
+		},
+	});
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -71,6 +71,17 @@ function doIt() {
     ln -sf "$PWD/.claude/CLAUDE.md" "$HOME/.pi/agent/CLAUDE.md"
     echo "Linked: $PWD/.claude/CLAUDE.md -> $HOME/.pi/agent/CLAUDE.md"
 
+    # Pi extensions are global and load from per-extension symlinks.
+    if [ -d "agents/extensions" ]; then
+        mkdir -p "$HOME/.pi/agent/extensions"
+        for extension in "$PWD"/agents/extensions/*.ts; do
+            [ -f "$extension" ] || continue
+            extension_name=$(basename "$extension")
+            ln -sfn "$extension" "$HOME/.pi/agent/extensions/$extension_name"
+            echo "Linked extension: $extension -> ~/.pi/agent/extensions/$extension_name"
+        done
+    fi
+
     # Symlink hooks
     if [ -d ".claude/hooks" ]; then
         mkdir -p "$HOME/.claude/hooks"

--- a/doctor.sh
+++ b/doctor.sh
@@ -235,6 +235,21 @@ if [ -d "$DOTFILES/agents/skills" ]; then
 else
     warn "Agent skills" "agents/skills missing from repo"
 fi
+if [ -d "$DOTFILES/agents/extensions" ]; then
+    total=0; linked=0
+    for extension in "$DOTFILES"/agents/extensions/*.ts; do
+        [ -f "$extension" ] || continue
+        total=$((total + 1))
+        case "$(readlink "$HOME/.pi/agent/extensions/$(basename "$extension")" 2>/dev/null)" in
+            "$DOTFILES"/*) linked=$((linked + 1)) ;;
+        esac
+    done
+    if [ "$total" -gt 0 ] && [ "$linked" -eq "$total" ]; then
+        pass "Pi extensions linked" "$linked/$total from agents/extensions"
+    else
+        warn "Pi extensions linked" "$linked/$total linked; run ./bootstrap.sh"
+    fi
+fi
 
 section "Shell & environment"
 if [ "$CI" -eq 1 ]; then

--- a/doctor.sh
+++ b/doctor.sh
@@ -215,23 +215,31 @@ fi
 section "Coding agents"
 check_tool "Claude Code" claude
 check_tool "Pi" pi
-# Skills are shared by both agents; bootstrap links them per-agent from
-# agents/skills — per-skill into ~/.claude/skills/, one dir into ~/.pi/agent.
+# Skills are shared by both agents; bootstrap links each skill per-agent from
+# agents/skills into ~/.claude/skills/ and ~/.pi/agent/skills/.
 if [ -d "$DOTFILES/agents/skills" ]; then
-    total=0; linked=0
+    total=0; claude_linked=0; pi_linked=0
     for skill_dir in "$DOTFILES"/agents/skills/*/; do
         [ -d "$skill_dir" ] || continue
         total=$((total + 1))
-        case "$(readlink "$HOME/.claude/skills/$(basename "$skill_dir")" 2>/dev/null)" in
-            "$DOTFILES"/*) linked=$((linked + 1)) ;;
+        skill_name=$(basename "$skill_dir")
+        case "$(readlink "$HOME/.claude/skills/$skill_name" 2>/dev/null)" in
+            "$DOTFILES"/*) claude_linked=$((claude_linked + 1)) ;;
+        esac
+        case "$(readlink "$HOME/.pi/agent/skills/$skill_name" 2>/dev/null)" in
+            "$DOTFILES"/*) pi_linked=$((pi_linked + 1)) ;;
         esac
     done
-    if [ "$total" -gt 0 ] && [ "$linked" -eq "$total" ]; then
-        pass "Claude skills linked" "$linked/$total from agents/skills"
+    if [ "$total" -gt 0 ] && [ "$claude_linked" -eq "$total" ]; then
+        pass "Claude skills linked" "$claude_linked/$total from agents/skills"
     else
-        warn "Claude skills linked" "$linked/$total linked; run ./bootstrap.sh"
+        warn "Claude skills linked" "$claude_linked/$total linked; run ./bootstrap.sh"
     fi
-    check_repo_link "Pi skills" "$HOME/.pi/agent/skills"
+    if [ "$total" -gt 0 ] && [ "$pi_linked" -eq "$total" ]; then
+        pass "Pi skills linked" "$pi_linked/$total from agents/skills"
+    else
+        warn "Pi skills linked" "$pi_linked/$total linked; run ./bootstrap.sh"
+    fi
 else
     warn "Agent skills" "agents/skills missing from repo"
 fi

--- a/test/doctor.sh
+++ b/test/doctor.sh
@@ -27,7 +27,7 @@ printf '%s\n' "$output" | grep -q "Summary" || fail "missing summary"
 
 fake_bin="$TMPDIR_ROOT/bin"
 healthy_home="$TMPDIR_ROOT/healthy-home"
-mkdir -p "$fake_bin" "$healthy_home/.claude/hooks" "$healthy_home/.pi/agent"
+mkdir -p "$fake_bin" "$healthy_home/.claude/hooks" "$healthy_home/.pi/agent/extensions"
 cat > "$fake_bin/tool" <<'EOF'
 #!/bin/sh
 name=${0##*/}
@@ -58,6 +58,7 @@ ln -s "$ROOT/.gitmessage" "$healthy_home/.gitmessage"
 echo "$healthy_home/.gitmessage" > "$healthy_home/.dotfiles_linked_files"
 ln -s "$ROOT/.claude/CLAUDE.md" "$healthy_home/.claude/CLAUDE.md"
 ln -s "$ROOT/.claude/CLAUDE.md" "$healthy_home/.pi/agent/CLAUDE.md"
+ln -s "$ROOT/agents/extensions/clear.ts" "$healthy_home/.pi/agent/extensions/clear.ts"
 for hook in "$ROOT"/.claude/hooks/*.sh; do
     ln -s "$hook" "$healthy_home/.claude/hooks/$(basename "$hook")"
 done
@@ -76,6 +77,7 @@ set -e
 [ "$status" -eq 0 ] || fail "expected a healthy CI setup to exit 0, got $status: $output"
 printf '%s\n' "$output" | grep -q "0 FAIL" || fail "healthy summary contains failures"
 printf '%s\n' "$output" | grep -Eq '^[[:space:]]+✓[[:space:]]+pgcli[[:space:]]' || fail "missing pgcli check"
+printf '%s\n' "$output" | grep -q "Pi extensions linked" || fail "missing Pi extensions check"
 
 set +e
 HOME="$healthy_home" PATH="$env_path" SHELL=/bin/zsh EDITOR=nvim "$ROOT/doctor.sh" --ci --strict >/dev/null 2>&1

--- a/test/doctor.sh
+++ b/test/doctor.sh
@@ -67,7 +67,10 @@ mkdir -p "$healthy_home/.claude/skills"
 for skill_dir in "$ROOT"/agents/skills/*/; do
     ln -s "$skill_dir" "$healthy_home/.claude/skills/$(basename "$skill_dir")"
 done
-ln -s "$ROOT/agents/skills" "$healthy_home/.pi/agent/skills"
+mkdir -p "$healthy_home/.pi/agent/skills"
+for skill_dir in "$ROOT"/agents/skills/*/; do
+    ln -s "$skill_dir" "$healthy_home/.pi/agent/skills/$(basename "$skill_dir")"
+done
 
 env_path="$fake_bin:/usr/bin:/bin"
 set +e
@@ -77,6 +80,7 @@ set -e
 [ "$status" -eq 0 ] || fail "expected a healthy CI setup to exit 0, got $status: $output"
 printf '%s\n' "$output" | grep -q "0 FAIL" || fail "healthy summary contains failures"
 printf '%s\n' "$output" | grep -Eq '^[[:space:]]+✓[[:space:]]+pgcli[[:space:]]' || fail "missing pgcli check"
+printf '%s\n' "$output" | grep -q "Pi skills linked" || fail "missing Pi skills check"
 printf '%s\n' "$output" | grep -q "Pi extensions linked" || fail "missing Pi extensions check"
 
 set +e

--- a/test/pi-clear-alias.sh
+++ b/test/pi-clear-alias.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Verify that /clear is installed as a global Pi extension and starts a session.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+EXTENSION="$ROOT/agents/extensions/clear.ts"
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+[ -f "$EXTENSION" ] || fail "missing /clear extension: $EXTENSION"
+
+home="$TMPDIR_ROOT/home"
+mkdir -p "$home"
+(
+    cd "$ROOT"
+    HOME="$home" TERM=xterm ./bootstrap.sh >/dev/null
+)
+
+link="$home/.pi/agent/extensions/clear.ts"
+[ -L "$link" ] || fail "Pi /clear extension was not linked"
+[ "$(readlink "$link")" = "$EXTENSION" ] || fail "Pi /clear extension points at the wrong file"
+
+node - "$home" "$TMPDIR_ROOT/sessions" <<'NODE'
+const { spawn } = require("node:child_process");
+
+const [home, sessionDir] = process.argv.slice(2);
+const pi = spawn("pi", [
+	"--offline",
+	"--no-context-files",
+	"--mode", "rpc",
+	"--session-dir", sessionDir,
+], {
+	env: { ...process.env, HOME: home },
+	stdio: ["pipe", "pipe", "pipe"],
+});
+
+const pending = new Map();
+let output = "";
+let stderr = "";
+
+function fail(message) {
+	console.error(`FAIL: ${message}`);
+	console.error(stderr || output);
+	pi.kill();
+	process.exit(1);
+}
+
+function send(type, data = {}) {
+	const id = crypto.randomUUID();
+	pi.stdin.write(`${JSON.stringify({ id, type, ...data })}\n`);
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			if (pending.delete(id)) reject(new Error(`timed out waiting for ${type}`));
+		}, 10_000);
+		pending.set(id, { resolve, reject, timeout });
+	});
+}
+
+pi.stdout.setEncoding("utf8");
+pi.stdout.on("data", (chunk) => {
+	output += chunk;
+	const lines = output.split("\n");
+	output = lines.pop();
+	for (const line of lines) {
+		if (!line) continue;
+		const message = JSON.parse(line);
+		if (message.type !== "response" || !message.id) continue;
+		const request = pending.get(message.id);
+		if (!request) continue;
+		pending.delete(message.id);
+		clearTimeout(request.timeout);
+		message.success ? request.resolve(message.data) : request.reject(new Error(message.error));
+	}
+});
+pi.stderr.setEncoding("utf8");
+pi.stderr.on("data", (chunk) => { stderr += chunk; });
+pi.on("error", (error) => fail(`could not start Pi: ${error.message}`));
+
+(async () => {
+	try {
+		const commands = await send("get_commands");
+		if (!commands.commands.some((command) => command.name === "clear")) {
+			fail("/clear is not registered");
+		}
+		const before = await send("get_state");
+		await send("prompt", { message: "/clear" });
+		const after = await send("get_state");
+		if (!before.sessionFile || !after.sessionFile || before.sessionFile === after.sessionFile) {
+			fail("/clear did not start a new session");
+		}
+		pi.stdin.end();
+	} catch (error) {
+		fail(error instanceof Error ? error.message : String(error));
+	}
+})();
+NODE
+
+echo "Pi /clear alias tests passed"

--- a/test/run.sh
+++ b/test/run.sh
@@ -56,6 +56,7 @@ else
     echo "==> Provisioning and verifying"
     docker run --rm -v "$REPO_ROOT:/dotfiles:ro" "$IMAGE" bash -lc "
 $PROVISION
+./test/pi-clear-alias.sh
 ./test/verify.sh
 ./doctor.sh --ci"
 fi


### PR DESCRIPTION
The health check expected `~/.pi/agent/skills` to be one repository symlink, although `bootstrap.sh` creates a directory containing per-skill links. Clean installations therefore failed `doctor.sh`.

Validate Pi skills individually, matching the bootstrap layout. Update the regression fixture to use that layout and assert the Pi skills check.